### PR TITLE
Update Foundry installation method in checklist

### DIFF
--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -3,9 +3,7 @@
 ## Development Stage
 
 * Install stable Foundry version
-  * [ ] Find the first [Foundry release](https://github.com/foundry-rs/foundry/releases) that is older than 7 days from now
-    * [ ] Insert the release URL here:
-  * [ ] Install the specified version via `foundryup --version git_tag_name`
+  * [ ] Install the stable version via `foundryup --install stable`
     ```
     Document the installation logs containing installed versions below:
     ```


### PR DESCRIPTION
## Summary
- Simplify Foundry installation instructions by using stable version directly
- Remove the "older than 7 days" rule for better clarity

## Changes
- Replace manual version selection process with `foundryup --install stable`
- Remove unnecessary steps for finding and specifying Foundry release URLs

## Test plan
- [ ] Verify that `foundryup --install stable` installs the correct stable version
- [ ] Confirm checklist remains clear and actionable