### PR TITLE
Adjust checks to foundry based deploy

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -20,6 +20,7 @@ EOA
 EOAs
 ERC
 EVM
+Ethereum
 Etherscan
 EthTx
 ExecLib

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -113,6 +113,7 @@ https
 immutable
 immutables
 invariants
+keystore
 kprFlatReward
 kprPctReward
 liquidationPenalty

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -188,7 +188,7 @@ Repo: https://github.com/makerdao/spells-mainnet
     * [ ] Avoid saving the values to the shell history (e.g. prefer a script or dynamically provided values `VAR=$(cat var.txt)`)
     * [ ] `ETH_RPC_URL` - an Ethereum RPC URL
     * [ ] `ETH_KEYSTORE` - a location to the keystore file, e.g. `~/.foundry/keystores/deploy`
-    * [ ] `ETH_KEYSTORE_PASSWORD` - a passphrase to the keystore file (omit setting it to be prompted during deploy)
+    * [ ] `ETH_KEYSTORE_PASSWORD` - a password to the keystore file (or omit setting it to be prompted during deploy)
     * [ ] `ETHERSCAN_API_KEY` - an Etherscan API key for spell verification
   * Check local env
     * [ ] `cast wallet address --keystore $ETH_KEYSTORE` shows the deployer address

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -140,7 +140,7 @@ Repo: https://github.com/makerdao/spells-mainnet
     * [ ] Sanity checks of all values added/updated by the spell function
     * [ ] End-to-end "happy path" interaction with the module
   * [ ] Tests PASS via `make test`
-* [ ] Ensure `DssExecLib` address used in current spell (`DssExecLib.address`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/makerdao/dss-exec-lib/releases/latest)
+* [ ] Ensure `DssExecLib` address used in current spell (`libraries` inside `foundry.toml`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/sky-ecosystem/dss-exec-lib/releases/latest)
 * [ ] Push committed content to already opened PR
 * [ ] Make sure CI PASS
 * [ ] Mark PR as "ready for review" and add reviewers
@@ -182,27 +182,17 @@ Repo: https://github.com/makerdao/spells-mainnet
 ## Deployment Stage
 
 * [ ] Wait for at least two "good to deploy" comments (containing local tests) from the official reviewers
-* Pre-deploy setup and checks (currently via `dapptools`)
-  * Set local environment variables (`.sethrc`)
-    * Deployer
-      * [ ] Avoid using the same deployer for mainnet and testnet (to avoid deploying contracts with the same address but different sources)
-      * [ ] `export ETH_PASSWORD=~/.env/password.txt`
-      * [ ] `export ETH_KEYSTORE=~/.ethereum/keystore`
-      * [ ] `export ETH_FROM=<address>`
-    * EIP1559
-      * [ ] Run `make estimate` to estimate gas
-      * [ ] `export ETH_GAS=X` with the output of the command above + a safety margin (e.g. `export ETH_GAS=6_000_000`)
-      * [ ] Check current gas price using `seth gas-price` and set `ETH_GAS_PRICE` accordingly (e.g. `50 gwei`)
-      * [ ] Consider adding margin to account for spikes (e.g. current gas price 25 `gwei`, 50 `gwei` could be set)
-      * [ ] `export ETH_GAS_PRICE=$(seth --to-wei X gwei)` (e.g. `export ETH_GAS_PRICE=25_000_000_000`)
-      * [ ] Check [current gas priority fee](https://etherscan.io/gastracker) and set `ETH_PRIO_FEE` accordingly
-      * [ ] `export ETH_PRIO_FEE=$(seth --to-wei X gwei)` (e.g. `export ETH_PRIO_FEE=2_000_000_000`)
-    * [ ] `export ETH_RPC_URL=<url>` to set mainnet RPC URL
-    * [ ] `export ETHERSCAN_API_KEY=<key>` to set Etherscan API KEY
-    * [ ] `source .sethrc` to make env vars available
+* Pre-deploy setup and checks (currently via Foundry)
+  * Set local environment variables
+    * [ ] Avoid using the same deployer for mainnet and testnet (to avoid deploying contracts with the same address but different sources)
+    * [ ] Avoid saving the values to the shell history (e.g. prefer a script or dynamically provided values `VAR=$(cat var.txt)`)
+    * [ ] `ETH_RPC_URL` - an Ethereum RPC URL
+    * [ ] `ETH_KEYSTORE` - a location to the keystore file, e.g. `~/.foundry/keystores/deploy`
+    * [ ] `ETH_KEYSTORE_PASSWORD` - a passphrase to the keystore file (omit setting it to be prompted during deploy)
+    * [ ] `ETHERSCAN_API_KEY` - an Etherscan API key for spell verification
   * Check local env
-    * [ ] `seth ls`
-    * [ ] `seth chain`
+    * [ ] `cast wallet address --keystore $ETH_KEYSTORE` shows the deployer address
+    * [ ] `cast chain-id` shows `1` for Mainnet
 * Deploy spell on mainnet
   * [ ] `make deploy`
   * Ensure `src/test/config.sol` is edited correctly
@@ -242,7 +232,7 @@ Repo: https://github.com/makerdao/spells-mainnet
       * [ ] Run old test script to ensure results are the same
       * [ ] IF results different, flag with Governance Facilitators
       * [ ] Obtain approval of the safety of the new script from both Spell Reviewers
-    * IF the PR modified `DssExecLib.address` file
+    * IF the PR modified `DssExecLib` address inside `foundry.toml`
       * [ ] Obtain approval of the safety of the new address from Spell Reviewers
       * [ ] Obtain approval of the safety of the new address from Governance Facilitators
 * [ ] Squash & Merge

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -285,7 +285,7 @@
   * [ ] Use the [DssExecLib Core Address Helpers](https://github.com/makerdao/dss-exec-lib/blob/master/src/DssExecLib.sol#L166) where possible (e.g. `DssExecLib.vat()`)
   * [ ] Where addresses are fetched from the `ChainLog`, the variable name must match the value of the ChainLog key for that address (e.g. `MCD_VAT` rather than `vat`), except where the archive pattern differs from this pattern (e.g. MKR)
 * Tests
-  * [ ] Ensure that the `DssExecLib.address` file is not being modified by the spell PR
+  * [ ] Ensure that the `DssExecLib` address inside `foundry.toml` is not being modified by the spell PR
   * [ ] Check all CI tests are passing as at the latest commit
     _Insert most recent commit hash where CI was passing_
   * [ ] Ensure every test function is declared as `public`
@@ -366,14 +366,14 @@ _Insert your local test logs here_
     * [ ] Valid license
     * [ ] Version matches
     * [ ] Optimizations are disabled
-    * [ ] dss-exec-lib library address used (under 'Libraries Used') matches the hardcoded local `DssExecLib.address` file
+    * [ ] dss-exec-lib library address used (under 'Libraries Used') matches the hardcoded local `DssExecLib` address inside `foundry.toml`
     * [ ] `deployed_spell_created` matches deployment timestamp
     * [ ] `deployed_spell_block` matches deployment block number
   * Manual checks
     * [ ] Ensure `make deploy-info tx=<tx>` matches [config](https://github.com/makerdao/spells-mainnet/blob/master/src/test/config.sol)
       * [ ] `deployed_spell_created` timestamp
       * [ ] `deployed_spell_block` block number
-    * [ ] Check again that the PR did not modify the `DssExecLib.address` file (e.g. look under the 'Files Changed' PR tab, etc.)
+    * [ ] Check again that the PR did not modify the `DssExecLib` address inside `foundry.toml`
     * [ ] Ensure Etherscan `Libraries Used` matches DssExecLib [Latest Release](https://github.com/makerdao/dss-exec-lib/releases/latest)
     * [ ] (For your tests to be accurate) git submodule hash matches [dss-exec-lib](https://github.com/makerdao/dss-exec-lib/releases/latest) latest release's tag commit and inspect diffs if doesn't match to ensure expected behaviour (Currently Non-Critical pending the next DssExecLib release, double check that the ExecLib used by the contract matches the latest release)
 * Tenderly Testnet checks
@@ -387,7 +387,7 @@ _Insert your local test logs here_
   * [ ] `make diff-archive-spell` for current date or `make diff-archive-spell date="YYYY-MM-DD"`
   * [ ] Ensure date corresponds to target Exec Doc date
 * Tests
-  * [ ] Ensure that the `DssExecLib.address` file is not being modified by the spell PR
+  * [ ] Ensure that the `DssExecLib` address inside `foundry.toml` is not being modified by the spell PR
   * [ ] Check all CI tests are passing as at the latest commit
     _Insert most recent commit hash where CI was passing_
   * [ ] Ensure that any other env variable does not affect execution of the tests (for example, by inspecting the output of `printenv | grep "FOUNDRY_\|DAPP_"`)


### PR DESCRIPTION
This PR adjusts the checklist to account for the changes in the dapptools to Foundry migration

See the PR inside the spell repo: https://github.com/sky-ecosystem/spells-mainnet/pull/491