### PR TITLE
Add SVM Payload Generation Review Checklist and Complement Star Spell Checklist with SVM Payload.

### DIFF
--- a/spell/star-spell-reviewer-checklist.md
+++ b/spell/star-spell-reviewer-checklist.md
@@ -161,7 +161,7 @@ This section outlines the review process and provides concrete action items for 
 
 - [ ] IF the spell triggers Solana actions via bridge:
     - LIST every SVM payload referenced in this spell:
-        - [ ] **`SVM_ACTION_NAME`** from REPOSITORY_URL
+        - [ ] `SVM_ACTION_NAME` from REPOSITORY_URL
             - [ ]  Payload hex data is correctly referenced in the EVM spell contract.
             - [ ]  SVM payload has been reviewed using the SVM Payload Generation Checklist.
             - [ ]  IF multiple SVM payloads are triggered, execution order is correct and documented.

--- a/spell/star-spell-reviewer-checklist.md
+++ b/spell/star-spell-reviewer-checklist.md
@@ -157,6 +157,15 @@ This section outlines the review process and provides concrete action items for 
   - [ ] IF Prime Agent spell can not be executed in a later block OR have to be executed sequentially to another Prime Agent spell, `direct execution` is clearly mentioned in the forum post together with elaborated explanation why it is needed.
   - [ ] The `direct execution` explanation makes sense on the technical level and can not be circumvented by the use of `isExecutable()` interface.
 
+### Cross-Chain SVM Payload
+
+- [ ] IF the spell triggers Solana actions via bridge:
+    - LIST every SVM payload referenced in this spell:
+        - [ ] **`SVM_ACTION_NAME`** from REPOSITORY_URL
+            - [ ]  Payload hex data is correctly referenced in the EVM spell contract.
+            - [ ]  SVM payload has been reviewed using the SVM Payload Generation Checklist.
+            - [ ]  IF multiple SVM payloads are triggered, execution order is correct and documented.
+
 #### On-boarding New Contracts
 - LIST every new contract present in the spell:
   - [CHAIN_NAME] `CONTRACT_NAME`, LINK_TO_THE_DEPLOYED_CONTRACT

--- a/spell/svm-payload-generation-checklist.md
+++ b/spell/svm-payload-generation-checklist.md
@@ -10,36 +10,36 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
 
 - LIST every spell action being deployed:
     - **`SCRIPT_NAME`**, scripts/SCRIPT_NAME/
-        - [ ]  Spell directory contains generate-payload.ts, validate.ts, and config.ts.
-        - [ ]  No unrelated files or changes in the solana payload generation directory.
-        - [ ]  Correct NETWORK_CONFIGS exported for both devnet and mainnet.
-        - [ ]  Single ACTION per payload scripts
+        - [ ] Spell directory contains generate-payload.ts, validate.ts, and config.ts.
+        - [ ] No unrelated files or changes in the solana payload generation directory.
+        - [ ] Correct NETWORK_CONFIGS exported for both devnet and mainnet.
+        - [ ] Single ACTION per payload scripts
 
 **Spell Description & Comments**
 
-- [ ]  Spell has clear description of Solana state changes.
-- [ ]  Every significant action is clearly commented in generate-payload.ts.
-- [ ]  Every account and parameter has valid source url (forum post, poll).
-- [ ]  Every parameter is clearly commented with expected before/after values.
+- [ ] Spell has clear description of Solana state changes.
+- [ ] Every significant action is clearly commented in generate-payload.ts.
+- [ ] Every account and parameter has valid source url (forum post, poll).
+- [ ] Every parameter is clearly commented with expected before/after values.
 
 **Proposed changes**
 
 - LIST every forum post proposing changes for this spell:
     - FORUM_POST_TITLE, FORUM_POST_URL
-        - [ ]  Forum post follows governance template.
-- [ ]  Verify spell content matches the combined scope of the forum posts listed above.
-- [ ]  Verify forum posts contain all Solana addresses (programs, PDAs, tokens) used in the spell.
+        - [ ] Forum post follows governance template.
+- [ ] Verify spell content matches the combined scope of the forum posts listed above.
+- [ ] Verify forum posts contain all Solana addresses (programs, PDAs, tokens) used in the spell.
 
 **Network Configuration**
 
 For each ACTION executed list:
 
-- [ ]  `ACTION` in scripts/SCRIPT_NAME
+- [ ] `ACTION` in scripts/SCRIPT_NAME
 - IF constants in src/ are used or were modified:
     - LIST every constant used from src/:
         - **`CONSTANT_NAME`** in src/FILE_NAME.ts: **`VALUE`** from EXTERNAL_SOURCE_URL
-            - [ ]  Value matches valid external source.
-            - [ ]  Constant is used correctly in spell config.
+            - [ ] Value matches valid external source.
+            - [ ] Constant is used correctly in spell config.
 - LIST network configurations from config.ts:
     - [devnet/mainnet/others] NETWORK_CONFIG_NAME, LIST every target account:
     - **`ACCOUNT_NAME`**: **`PUBKEY`** from EXTERNAL_SOURCE_URL
@@ -53,51 +53,51 @@ For each ACTION executed list:
     - **`ACCOUNT_ADDRESS`** (ACCOUNT_NAME)
         - LIST every field that should change:
             - **`FIELD_NAME`** from **`OLD_VALUE`** to **`NEW_VALUE`** from EXTERNAL_SOURCE_URL
-                - [ ]  Value change matches external source.
-                - [ ]  Simulation shows correct state change.
+                - [ ] Value change matches external source.
+                - [ ] Simulation shows correct state change.
         - LIST every field that should NOT change:
             - **`FIELD_NAME`** remains **`VALUE`**
-                - [ ]  Simulation confirms field is unchanged.
+                - [ ] Simulation confirms field is unchanged.
 
 **Code Structure & Quality**
 
-- [ ]  No unused imports, interfaces, or variables.
-- [ ]  All addresses are valid Solana public keys.
-- [ ]  Instruction data encoding matches target program interface.
-- [ ]  No hardcoded addresses where config values should be used or constants in source
+- [ ] No unused imports, interfaces, or variables.
+- [ ] All addresses are valid Solana public keys.
+- [ ] Instruction data encoding matches target program interface.
+- [ ] No hardcoded addresses where config values should be used or constants in source
 
 **Dependency checks**
 
 - LIST every package used in the spell:
     - **`PACKAGE_NAME@VERSION`**
-        - [ ]  Version matches package.json.
-        - [ ]  Package is updated or in a safer version
-- [ ]  Anchor/SDK version matches program deployment.
+        - [ ] Version matches package.json.
+        - [ ] Package is updated or in a safer version
+- [ ] Anchor/SDK version matches program deployment.
 
 **Payload Generation**
 
-- [ ]  Run generation script: **`NETWORK=[network] ts-node ./scripts/SCRIPT_NAME/generate-payload.ts --file FILENAME`**
-- [ ]  Output file created: **`FILENAME-NETWORK.txt`**
-- [ ]  Payload contains hex-encoded data (no errors in generation).
+- [ ] Run generation script: **`NETWORK=[network] ts-node ./scripts/SCRIPT_NAME/generate-payload.ts --file FILENAME`**
+- [ ] Output file created: **`FILENAME-NETWORK.txt`**
+- [ ] Payload contains hex-encoded data (no errors in generation).
 
 ### **Validation Stage**
 
 **Simulation Execution**
 
-- [ ]  Run validation script: **`NETWORK=[network] ts-node ./scripts/SPELL_NAME/validate.ts --file FILENAME`**
-- [ ]  Simulation completes successfully (no errors).
-- [ ]  All expected logs are present.
-- [ ]  No unexpected program invocations.
+- [ ] Run validation script: **`NETWORK=[network] ts-node ./scripts/SPELL_NAME/validate.ts --file FILENAME`**
+- [ ] Simulation completes successfully (no errors).
+- [ ] All expected logs are present.
+- [ ] No unexpected program invocations.
 
 **Testing**
 
 - LIST each spell action (each instruction in the payload):
     - INTENDED_SPELL_ACTION tested via TEST_NAME in validate.ts
-        - [ ]  Test ensures the new value was set correctly.
-        - [ ]  Test uses **`assertNoAccountChanges`** for accounts that shouldn't change.
-        - [ ]  Test verifies account state before and after.
-- [ ]  All actions are covered by validation tests.
-- [ ]  All assertions pass locally at COMMIT_HASH:
+        - [ ] Test ensures the new value was set correctly.
+        - [ ] Test uses **`assertNoAccountChanges`** for accounts that shouldn't change.
+        - [ ] Test verifies account state before and after.
+- [ ] All actions are covered by validation tests.
+- [ ] All assertions pass locally at COMMIT_HASH:
 
 ```
 EXECUTED_TESTS_LOGS 
@@ -107,4 +107,4 @@ EXECUTED_TESTS_LOGS
 
 For each `ACTION` list the payload generated:
 
-- [ ]  `ACTION_NAME`, `payload`
+- [ ] `ACTION_NAME`, `payload`

--- a/spell/svm-payload-generation-checklist.md
+++ b/spell/svm-payload-generation-checklist.md
@@ -1,12 +1,12 @@
-# **SVM Spell Payload Generation Checklist**
+# SVM Spell Payload Generation Checklist
 
 This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cross-chain governance payloads that execute on Solana via Bridge.
 
-## **SVM Spell Payload Generation Review Process**
+## SVM Spell Payload Generation Review Process
 
-### **Development Stage**
+### Development Stage
 
-**Preparation**
+#### Preparation
 
 - LIST every spell action being deployed:
     - **`SCRIPT_NAME`**, scripts/SCRIPT_NAME/, COMMIT_HASH
@@ -16,7 +16,7 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
         - [ ] Correct NETWORK_CONFIGS exported for both devnet and mainnet.
         - [ ] Single ACTION per payload scripts
 
-**Proposed Changes**
+#### Proposed Changes
 
 - LIST every forum post proposing changes for this spell:
     - FORUM_POST_TITLE, FORUM_POST_URL
@@ -24,7 +24,7 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
 - [ ] Verify spell content matches the combined scope of the forum posts listed above.
 - [ ] Verify forum posts contain all Solana addresses (programs, PDAs, tokens) used in the spell.
 
-**Spell Description & Comments**
+#### Spell Description & Comments
 
 - [ ] Spell has clear description of Solana state changes.
 - [ ] Every significant action is clearly commented in generate-payload.ts.
@@ -32,7 +32,7 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
 - [ ] Every parameter is clearly commented with expected before/after values.
 
 
-**Network Configuration**
+#### Network Configuration
 
 For each ACTION executed list:
 
@@ -49,7 +49,7 @@ For each ACTION executed list:
     - Account exists on target network.
     - Account owner matches expected program.
 
-**State Change Verification** 
+#### State Change Verification
 
 - LIST every account:
     - **`ACCOUNT_ADDRESS`** (ACCOUNT_NAME)
@@ -61,14 +61,14 @@ For each ACTION executed list:
             - **`FIELD_NAME`** remains **`VALUE`**
                 - [ ] Simulation confirms field is unchanged.
 
-**Code Structure & Quality**
+#### Code Structure & Quality
 
 - [ ] No unused imports, interfaces, or variables.
 - [ ] All addresses are valid Solana public keys.
 - [ ] Instruction data encoding matches target program interface.
 - [ ] No hardcoded addresses where config values should be used or constants in source
 
-**Dependency Checks**
+#### Dependency Checks
 
 - LIST every package used in the spell:
     - **`PACKAGE_NAME@VERSION`**
@@ -76,22 +76,22 @@ For each ACTION executed list:
         - [ ] Package is updated or in a safer version
 - [ ] Anchor/SDK version matches program deployment.
 
-**Payload Generation**
+#### Payload Generation
 
 - [ ] Run generation script: **`NETWORK=[network] ts-node ./scripts/SCRIPT_NAME/generate-payload.ts --file FILENAME`**
 - [ ] Output file created: **`FILENAME-NETWORK.txt`**
 - [ ] Payload contains hex-encoded data (no errors in generation).
 
-### **Validation Stage**
+### Validation Stage
 
-**Simulation Execution**
+#### Simulation Execution
 
 - [ ] Run validation script: **`NETWORK=[network] ts-node ./scripts/SPELL_NAME/validate.ts --file FILENAME`**
 - [ ] Simulation completes successfully (no errors).
 - [ ] All expected logs are present.
 - [ ] No unexpected program invocations.
 
-**Testing**
+#### Testing
 
 - LIST each spell action (each instruction in the payload):
     - INTENDED_SPELL_ACTION tested via TEST_NAME in validate.ts
@@ -105,7 +105,7 @@ For each ACTION executed list:
 EXECUTED_TESTS_LOGS 
 ```
 
-**Output**
+#### Output
 
 For each `ACTION` list the payload generated:
 

--- a/spell/svm-payload-generation-checklist.md
+++ b/spell/svm-payload-generation-checklist.md
@@ -73,29 +73,26 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
 
 ### Validation
 
-#### Simulation Execution
-
-- [ ] Run validation script: `NETWORK=[network] ts-node ./scripts/SPELL_NAME/validate.ts --file FILENAME`
-- [ ] Simulation completes successfully (no errors).
-- [ ] All expected logs are present.
-- [ ] No unexpected program invocations.
-
 #### Testing
 
 - LIST each spell action (each instruction in the payload):
-    - INTENDED_SPELL_ACTION tested via TEST_NAME in validate.ts
+    - SCRIPT_NAME tested via TEST_NAME in validate.ts
         - [ ] Test ensures the new value was set correctly.
         - [ ] Test uses `assertNoAccountChanges` for accounts that shouldn't change.
         - [ ] Test verifies account state before and after.
-- [ ] All actions are covered by validation tests.
-- [ ] All assertions pass locally at COMMIT_HASH:
+        - [ ] Output log:
+            ```
+            EXECUTED_TESTS_LOGS 
+            ```
 
-```
-EXECUTED_TESTS_LOGS 
-```
+- [ ] All scripts are covered by validation tests.
+- [ ] All assertions pass locally at `COMMIT_HASH`
 
-#### Output
 
-For each `ACTION` list the payload generated:
+#### Simulation Execution and Output
 
-- [ ] `ACTION_NAME`, `payload`
+For each SCRIPT list the payload generated:
+    - `ACTION_NAME`
+        - [ ] Run validation script: `NETWORK=[network] ts-node ./scripts/SPELL_NAME/validate.ts --file FILENAME`
+        - [ ] Simulation completes successfully (no errors).
+        - [ ] `payload_generated` matches to `SCRIPT_NAME.txt`

--- a/spell/svm-payload-generation-checklist.md
+++ b/spell/svm-payload-generation-checklist.md
@@ -9,10 +9,10 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
 **Preparation**
 
 - LIST every spell action being deployed:
-    - **`SCRIPT_NAME`**, scripts/SCRIPT_NAME/
+    - **`SCRIPT_NAME`**, scripts/SCRIPT_NAME/, COMMIT_HASH
         - [ ] Spell directory contains generate-payload.ts, validate.ts, and config.ts.
         - [ ] `SCRIPT_NAME.txt` file generated in the `SCRIPT_NAME` folder.
-        - [ ] No unrelated files or changes in the solana payload generation directory.
+        - [ ] No unrelated files added in the solana payload generation directory.
         - [ ] Correct NETWORK_CONFIGS exported for both devnet and mainnet.
         - [ ] Single ACTION per payload scripts
 

--- a/spell/svm-payload-generation-checklist.md
+++ b/spell/svm-payload-generation-checklist.md
@@ -16,6 +16,14 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
         - [ ] Correct NETWORK_CONFIGS exported for both devnet and mainnet.
         - [ ] Single ACTION per payload scripts
 
+**Proposed Changes**
+
+- LIST every forum post proposing changes for this spell:
+    - FORUM_POST_TITLE, FORUM_POST_URL
+        - [ ] Forum post follows governance template.
+- [ ] Verify spell content matches the combined scope of the forum posts listed above.
+- [ ] Verify forum posts contain all Solana addresses (programs, PDAs, tokens) used in the spell.
+
 **Spell Description & Comments**
 
 - [ ] Spell has clear description of Solana state changes.
@@ -23,13 +31,6 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
 - [ ] Every account and parameter has valid source url (forum post, poll).
 - [ ] Every parameter is clearly commented with expected before/after values.
 
-**Proposed changes**
-
-- LIST every forum post proposing changes for this spell:
-    - FORUM_POST_TITLE, FORUM_POST_URL
-        - [ ] Forum post follows governance template.
-- [ ] Verify spell content matches the combined scope of the forum posts listed above.
-- [ ] Verify forum posts contain all Solana addresses (programs, PDAs, tokens) used in the spell.
 
 **Network Configuration**
 
@@ -67,7 +68,7 @@ For each ACTION executed list:
 - [ ] Instruction data encoding matches target program interface.
 - [ ] No hardcoded addresses where config values should be used or constants in source
 
-**Dependency checks**
+**Dependency Checks**
 
 - LIST every package used in the spell:
     - **`PACKAGE_NAME@VERSION`**

--- a/spell/svm-payload-generation-checklist.md
+++ b/spell/svm-payload-generation-checklist.md
@@ -36,17 +36,11 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
 
 - List for each script:
     - [ ] `SCRIPT` in `scripts/SCRIPT_NAME`
-    - IF constants in `src/` are used or were modified:
-        - LIST every constant used from `src/`:
-            - `CONSTANT_NAME` in `src/FILE_NAME.ts`: `VALUE` from EXTERNAL_SOURCE_URL
-                - [ ] Value matches valid external source.
-                - [ ] Constant is used correctly in spell config.
-    - LIST network configurations from config.ts:
-        - [devnet/mainnet/others] NETWORK_CONFIG_NAME, LIST every target account:
-        - `ACCOUNT_NAME`: `PUBKEY` from EXTERNAL_SOURCE_URL
-        - Address matches valid external source.
-        - Account exists on target network.
-        - Account owner matches expected program.
+    - LIST network configurations from `config.ts`:
+        - `NETWORK_CONFIG_NAME`
+        - LIST every target account:
+            - [ ] `FIELD_NAME`: `PUBKEY`
+            - [ ] Address matches valid external source.
 
 #### State Change Verification
 

--- a/spell/svm-payload-generation-checklist.md
+++ b/spell/svm-payload-generation-checklist.md
@@ -9,7 +9,7 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
 #### Preparation
 
 - LIST every spell action being deployed:
-    - `SCRIPT_NAME`, scripts/SCRIPT_NAME/, COMMIT_HASH
+    - `SCRIPT_NAME`, `scripts/SCRIPT_NAME/`
         - [ ] Spell directory contains generate-payload.ts, validate.ts, and config.ts.
         - [ ] `SCRIPT_NAME.txt` file generated in the `SCRIPT_NAME` folder.
         - [ ] No unrelated files added in the solana payload generation directory.

--- a/spell/svm-payload-generation-checklist.md
+++ b/spell/svm-payload-generation-checklist.md
@@ -1,0 +1,110 @@
+# **SVM Spell Payload Generation Checklist**
+
+This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cross-chain governance payloads that execute on Solana via Bridge.
+
+## **SVM Spell Payload Generation Review Process**
+
+### **Development Stage**
+
+**Preparation**
+
+- LIST every spell action being deployed:
+    - **`SCRIPT_NAME`**, scripts/SCRIPT_NAME/
+        - [ ]  Spell directory contains generate-payload.ts, validate.ts, and config.ts.
+        - [ ]  No unrelated files or changes in the solana payload generation directory.
+        - [ ]  Correct NETWORK_CONFIGS exported for both devnet and mainnet.
+        - [ ]  Single ACTION per payload scripts
+
+**Spell Description & Comments**
+
+- [ ]  Spell has clear description of Solana state changes.
+- [ ]  Every significant action is clearly commented in generate-payload.ts.
+- [ ]  Every account and parameter has valid source url (forum post, poll).
+- [ ]  Every parameter is clearly commented with expected before/after values.
+
+**Proposed changes**
+
+- LIST every forum post proposing changes for this spell:
+    - FORUM_POST_TITLE, FORUM_POST_URL
+        - [ ]  Forum post follows governance template.
+- [ ]  Verify spell content matches the combined scope of the forum posts listed above.
+- [ ]  Verify forum posts contain all Solana addresses (programs, PDAs, tokens) used in the spell.
+
+**Network Configuration**
+
+For each ACTION executed list:
+
+- [ ]  `ACTION` in scripts/SCRIPT_NAME
+- IF constants in src/ are used or were modified:
+    - LIST every constant used from src/:
+        - **`CONSTANT_NAME`** in src/FILE_NAME.ts: **`VALUE`** from EXTERNAL_SOURCE_URL
+            - [ ]  Value matches valid external source.
+            - [ ]  Constant is used correctly in spell config.
+- LIST network configurations from config.ts:
+    - [devnet/mainnet/others] NETWORK_CONFIG_NAME, LIST every target account:
+    - **`ACCOUNT_NAME`**: **`PUBKEY`** from EXTERNAL_SOURCE_URL
+    - Address matches valid external source.
+    - Account exists on target network.
+    - Account owner matches expected program.
+
+**State Change Verification** 
+
+- LIST every account:
+    - **`ACCOUNT_ADDRESS`** (ACCOUNT_NAME)
+        - LIST every field that should change:
+            - **`FIELD_NAME`** from **`OLD_VALUE`** to **`NEW_VALUE`** from EXTERNAL_SOURCE_URL
+                - [ ]  Value change matches external source.
+                - [ ]  Simulation shows correct state change.
+        - LIST every field that should NOT change:
+            - **`FIELD_NAME`** remains **`VALUE`**
+                - [ ]  Simulation confirms field is unchanged.
+
+**Code Structure & Quality**
+
+- [ ]  No unused imports, interfaces, or variables.
+- [ ]  All addresses are valid Solana public keys.
+- [ ]  Instruction data encoding matches target program interface.
+- [ ]  No hardcoded addresses where config values should be used or constants in source
+
+**Dependency checks**
+
+- LIST every package used in the spell:
+    - **`PACKAGE_NAME@VERSION`**
+        - [ ]  Version matches package.json.
+        - [ ]  Package is updated or in a safer version
+- [ ]  Anchor/SDK version matches program deployment.
+
+**Payload Generation**
+
+- [ ]  Run generation script: **`NETWORK=[network] ts-node ./scripts/SCRIPT_NAME/generate-payload.ts --file FILENAME`**
+- [ ]  Output file created: **`FILENAME-NETWORK.txt`**
+- [ ]  Payload contains hex-encoded data (no errors in generation).
+
+### **Validation Stage**
+
+**Simulation Execution**
+
+- [ ]  Run validation script: **`NETWORK=[network] ts-node ./scripts/SPELL_NAME/validate.ts --file FILENAME`**
+- [ ]  Simulation completes successfully (no errors).
+- [ ]  All expected logs are present.
+- [ ]  No unexpected program invocations.
+
+**Testing**
+
+- LIST each spell action (each instruction in the payload):
+    - INTENDED_SPELL_ACTION tested via TEST_NAME in validate.ts
+        - [ ]  Test ensures the new value was set correctly.
+        - [ ]  Test uses **`assertNoAccountChanges`** for accounts that shouldn't change.
+        - [ ]  Test verifies account state before and after.
+- [ ]  All actions are covered by validation tests.
+- [ ]  All assertions pass locally at COMMIT_HASH:
+
+```
+EXECUTED_TESTS_LOGS 
+```
+
+**Output**
+
+For each `ACTION` list the payload generated:
+
+- [ ]  `ACTION_NAME`, `payload`

--- a/spell/svm-payload-generation-checklist.md
+++ b/spell/svm-payload-generation-checklist.md
@@ -11,6 +11,7 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
 - LIST every spell action being deployed:
     - **`SCRIPT_NAME`**, scripts/SCRIPT_NAME/
         - [ ] Spell directory contains generate-payload.ts, validate.ts, and config.ts.
+        - [ ] `SCRIPT_NAME.txt` file generated in the `SCRIPT_NAME` folder.
         - [ ] No unrelated files or changes in the solana payload generation directory.
         - [ ] Correct NETWORK_CONFIGS exported for both devnet and mainnet.
         - [ ] Single ACTION per payload scripts

--- a/spell/svm-payload-generation-checklist.md
+++ b/spell/svm-payload-generation-checklist.md
@@ -4,12 +4,12 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
 
 ## SVM Spell Payload Generation Review Process
 
-### Development Stage
+### Development
 
 #### Preparation
 
 - LIST every spell action being deployed:
-    - **`SCRIPT_NAME`**, scripts/SCRIPT_NAME/, COMMIT_HASH
+    - `SCRIPT_NAME`, scripts/SCRIPT_NAME/, COMMIT_HASH
         - [ ] Spell directory contains generate-payload.ts, validate.ts, and config.ts.
         - [ ] `SCRIPT_NAME.txt` file generated in the `SCRIPT_NAME` folder.
         - [ ] No unrelated files added in the solana payload generation directory.
@@ -34,32 +34,27 @@ This checklist complements the EVM Prime Agent Spells Reviewer Checklist for cr
 
 #### Network Configuration
 
-For each ACTION executed list:
-
-- [ ] `ACTION` in scripts/SCRIPT_NAME
-- IF constants in src/ are used or were modified:
-    - LIST every constant used from src/:
-        - **`CONSTANT_NAME`** in src/FILE_NAME.ts: **`VALUE`** from EXTERNAL_SOURCE_URL
-            - [ ] Value matches valid external source.
-            - [ ] Constant is used correctly in spell config.
-- LIST network configurations from config.ts:
-    - [devnet/mainnet/others] NETWORK_CONFIG_NAME, LIST every target account:
-    - **`ACCOUNT_NAME`**: **`PUBKEY`** from EXTERNAL_SOURCE_URL
-    - Address matches valid external source.
-    - Account exists on target network.
-    - Account owner matches expected program.
+- List for each script:
+    - [ ] `SCRIPT` in `scripts/SCRIPT_NAME`
+    - IF constants in `src/` are used or were modified:
+        - LIST every constant used from `src/`:
+            - `CONSTANT_NAME` in `src/FILE_NAME.ts`: `VALUE` from EXTERNAL_SOURCE_URL
+                - [ ] Value matches valid external source.
+                - [ ] Constant is used correctly in spell config.
+    - LIST network configurations from config.ts:
+        - [devnet/mainnet/others] NETWORK_CONFIG_NAME, LIST every target account:
+        - `ACCOUNT_NAME`: `PUBKEY` from EXTERNAL_SOURCE_URL
+        - Address matches valid external source.
+        - Account exists on target network.
+        - Account owner matches expected program.
 
 #### State Change Verification
 
 - LIST every account:
-    - **`ACCOUNT_ADDRESS`** (ACCOUNT_NAME)
+    - `ACCOUNT_ADDRESS` (ACCOUNT_NAME) ,
         - LIST every field that should change:
-            - **`FIELD_NAME`** from **`OLD_VALUE`** to **`NEW_VALUE`** from EXTERNAL_SOURCE_URL
-                - [ ] Value change matches external source.
-                - [ ] Simulation shows correct state change.
-        - LIST every field that should NOT change:
-            - **`FIELD_NAME`** remains **`VALUE`**
-                - [ ] Simulation confirms field is unchanged.
+            - `FIELD_NAME` from `OLD_VALUE` to `NEW_VALUE`
+                - [ ] Value change matches to forum post.
 
 #### Code Structure & Quality
 
@@ -70,23 +65,23 @@ For each ACTION executed list:
 
 #### Dependency Checks
 
-- LIST every package used in the spell:
-    - **`PACKAGE_NAME@VERSION`**
+- LIST every package changed or added in the spell:
+    - `PACKAGE_NAME@VERSION`
         - [ ] Version matches package.json.
         - [ ] Package is updated or in a safer version
 - [ ] Anchor/SDK version matches program deployment.
 
 #### Payload Generation
 
-- [ ] Run generation script: **`NETWORK=[network] ts-node ./scripts/SCRIPT_NAME/generate-payload.ts --file FILENAME`**
-- [ ] Output file created: **`FILENAME-NETWORK.txt`**
+- [ ] Run generation script: `NETWORK=[network] ts-node ./scripts/SCRIPT_NAME/generate-payload.ts --file FILENAME`
+- [ ] Output file created: `FILENAME-NETWORK.txt`
 - [ ] Payload contains hex-encoded data (no errors in generation).
 
-### Validation Stage
+### Validation
 
 #### Simulation Execution
 
-- [ ] Run validation script: **`NETWORK=[network] ts-node ./scripts/SPELL_NAME/validate.ts --file FILENAME`**
+- [ ] Run validation script: `NETWORK=[network] ts-node ./scripts/SPELL_NAME/validate.ts --file FILENAME`
 - [ ] Simulation completes successfully (no errors).
 - [ ] All expected logs are present.
 - [ ] No unexpected program invocations.
@@ -96,7 +91,7 @@ For each ACTION executed list:
 - LIST each spell action (each instruction in the payload):
     - INTENDED_SPELL_ACTION tested via TEST_NAME in validate.ts
         - [ ] Test ensures the new value was set correctly.
-        - [ ] Test uses **`assertNoAccountChanges`** for accounts that shouldn't change.
+        - [ ] Test uses `assertNoAccountChanges` for accounts that shouldn't change.
         - [ ] Test verifies account state before and after.
 - [ ] All actions are covered by validation tests.
 - [ ] All assertions pass locally at COMMIT_HASH:


### PR DESCRIPTION
## Summary
Introduces a review checklist for SVM payload generation in cross-chain governance actions, covering both the SVM checklist and EVM spell integration.

## Rationale
Sky's governance will execute cross-chain actions on SVM via LayerZero bridge. We need systematic review processes for SVM payloads similar to our EVM spell reviews.

Cross-chain governance actions follow this two-stage review process:

1. **SVM Payload Generation**
   - SVM instructions payloads are generated and serialized
   - Reviewed using the **SVM Payload Generation Checklist**
   - Ensures SVM correctness

2. **EVM Spell Integration** 
   - EVM spell references the SVM payload hex data
   - Bridges the message to Solana via Wormhole/LayerZero
   - Reviewed using the **Cross-Chain SVM Payload** section in the Star Spell Reviewer Checklist
   - Validates correct payload reference and ordering.

Both checklists work together to ensure end-to-end correctness of cross-chain governance actions.

SVM Payload Generation: https://github.com/keel-fi/crosschain-gov-solana-spell-payloads
