### PR TITLE
Harden crafter and reviewer `foundry` installation step

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -65,7 +65,6 @@ RPC
 RWA
 RWAXXX
 RWAXYZ
-SHA
 Repo
 Solmate
 SPDX

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -167,6 +167,7 @@ unaudited
 untrusted
 upgradability
 upgradable
+verifier
 vnet
 vscode
 whitespace

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -65,6 +65,7 @@ RPC
 RWA
 RWAXXX
 RWAXYZ
+SHA
 Repo
 Solmate
 SPDX

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -138,6 +138,7 @@ permissioning
 permittedDrop
 precomputed
 prepended
+prerelease
 redemptions
 repos
 RPC
@@ -167,6 +168,7 @@ untrusted
 upgradability
 upgradable
 verifier
+verifier's
 vnet
 vscode
 whitespace

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -171,7 +171,6 @@ untrusted
 upgradability
 upgradable
 verifier
-verifier's
 vnet
 vscode
 whitespace

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -42,13 +42,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete verifier output here_
     ```
   * IF the verifier fails
-    * IF any of these verifier output lines is missing:
+    * IF the failed verifier requires installation and reports all of:
       * `Required action: install`
       * `Desired Foundry release: vMAJOR.MINOR.PATCH`
       * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-      * [ ] Stop the workflow
-      * [ ] Diagnose the verifier failure
-    * OTHERWISE IF the failed verifier requires installation and reports both the desired release and its exact installation command
       * Review official security sources for the release identified by the verifier
         * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
         * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the release
@@ -64,13 +61,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         ```
       * IF none of the checked sources identifies an unresolved issue affecting the desired release
         * [ ] Run the exact `Installation command` printed by the verifier
-        * IF the installer fails
-          * [ ] Stop the workflow
-          * [ ] Resolve the installer failure
-        * OTHERWISE IF the installer succeeds
+        * IF the installer succeeds
           * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
           * [ ] Run `make verify-foundry`
           * [ ] Confirm that the verifier exits `0`
+        * OTHERWISE IF the installer fails
+          * [ ] Stop the workflow
+          * [ ] Resolve the installer failure
       * OTHERWISE IF the checked sources identify an unresolved issue affecting the desired release
         * [ ] Stop the workflow
         * [ ] Notify the spell team
@@ -94,21 +91,24 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
           * [ ] Confirm that the spell-team approval explicitly waives the 14-day cooling period
           * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
         * IF the exact-release verifier fails
-          * IF any of these exact-release verifier output requirements is missing:
+          * IF the failed exact-release verifier requires installation for the mitigation release and reports all of:
             * `Required action: install`
             * `Desired Foundry release: vMAJOR.MINOR.PATCH`
             * `Installation command:` matching the mitigation release and including `ignore-age=1` when the cooling period is waived
-            * [ ] Stop the workflow
-            * [ ] Diagnose the verifier failure
-          * OTHERWISE IF the failed exact-release verifier requires installation for the mitigation release and prints a matching installation command
             * [ ] Run the exact printed `Installation command`
-            * IF the installer fails
-              * [ ] Stop the workflow
-              * [ ] Resolve the installer failure
-            * OTHERWISE IF the installer succeeds
+            * IF the installer succeeds
               * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
               * [ ] Rerun the same exact-release verifier
               * [ ] Confirm that the verifier exits `0`
+            * OTHERWISE IF the installer fails
+              * [ ] Stop the workflow
+              * [ ] Resolve the installer failure
+          * OTHERWISE IF the exact-release verifier fails for any other reason
+            * [ ] Stop the workflow
+            * [ ] Diagnose the verifier failure
+    * OTHERWISE IF the verifier fails for any other reason
+      * [ ] Stop the workflow
+      * [ ] Diagnose the verifier failure
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -38,9 +38,31 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Verify Foundry tooling
   * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and run `make verify-foundry`
   * [ ] IF using a force release, record the upstream reference, explicit spell-team approval, and exact release tag, then run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1` instead
-  * [ ] IF verification reports a different desired release, check and record Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice; stop and notify the spell team if an unresolved issue affects that release
-  * [ ] IF verification reports a different desired release and no unresolved issue affects it, run the exact installation command reported by the verifier, then rerun the same verifier command
-  * [ ] Confirm that final verification exits `0` and record the complete verifier output plus installer output IF installation ran
+    ```text
+    Upstream reference:
+    Spell-team approval:
+    Release: vMAJOR.MINOR.PATCH
+    ```
+  * [ ] IF verification exits `0`, record the complete verifier output
+    ```text
+    _Insert the complete verifier output here_
+    ```
+  * OTHERWISE
+    * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice; stop and notify the spell team if an unresolved issue affects that release
+      ```text
+      Desired release:
+      Security sources checked:
+      Outstanding issues: None found / _Insert references_
+      ```
+    * [ ] IF no unresolved issue affects the desired release, run the exact installation command reported by the verifier
+    * [ ] Rerun the same verifier command, confirm that it exits `0`, and record the complete verifier and installer outputs
+      ```text
+      Installer output:
+      _Insert the complete installer output here_
+
+      Verifier output:
+      _Insert the complete verifier output here_
+      ```
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -65,9 +65,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
           * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
           * [ ] Run `make verify-foundry`
           * [ ] Confirm that the verifier exits `0`
-        * OTHERWISE IF the installer fails
-          * [ ] Stop the workflow
-          * [ ] Resolve the installer failure
       * OTHERWISE IF the checked sources identify an unresolved issue affecting the desired release
         * [ ] Stop the workflow
         * [ ] Notify the spell team
@@ -100,15 +97,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
               * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
               * [ ] Rerun the same exact-release verifier
               * [ ] Confirm that the verifier exits `0`
-            * OTHERWISE IF the installer fails
-              * [ ] Stop the workflow
-              * [ ] Resolve the installer failure
-          * OTHERWISE IF the exact-release verifier fails for any other reason
-            * [ ] Stop the workflow
-            * [ ] Diagnose the verifier failure
-    * OTHERWISE IF the verifier fails for any other reason
-      * [ ] Stop the workflow
-      * [ ] Diagnose the verifier failure
+  * IF any `setup-foundry.sh` invocation exits nonzero without printing all of:
+    * `Required action: install`
+    * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+    * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when the cooling period is waived
+    * [ ] Stop the workflow
+    * [ ] Diagnose the failure
+    * [ ] Resolve the failure
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -36,48 +36,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 ## Development Stage
 
 * Verify Foundry tooling
-  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md)
-  * [ ] IF using the normal release policy, verify the Foundry binaries currently in PATH
-    ```bash
-    make verify-foundry
-    ```
-  * [ ] IF using a force release that cannot wait for the 14-day cooling period, confirm that it fixes an urgent security issue and record the upstream reference, explicit spell-team approval, and exact release tag
-    ```text
-    Upstream reference:
-    Spell-team approval:
-    Release: vMAJOR.MINOR.PATCH
-    ```
-  * [ ] IF using a force release, verify the approved release instead of running the normal verifier command
-    ```bash
-    make verify-foundry release=vMAJOR.MINOR.PATCH force=1
-    ```
-  * [ ] Confirm the verifier exit status. Exit `0` means the installed release matches the desired release and no installation checks are required. Any nonzero exit means verification failed; continue only if the output reports a desired release and exact installation command, otherwise resolve the failure before continuing
-  * [ ] IF verification failed, record the desired release and installation command reported by the verifier
-    ```text
-    Desired install version:
-    Published at:
-    Release URL:
-    Installation command:
-    ```
-  * [ ] IF verification failed, check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the desired release's official notes, and any official incident notice linked from those sources for unresolved security issues affecting that release
-  * [ ] IF verification failed, record the version-specific security check as evidence
-    ```text
-    Checked at (UTC):
-    Sources checked:
-    Outstanding issues affecting the desired version: None found / _Insert references_
-    ```
-  * [ ] IF an unresolved security issue affects the desired release, stop, notify the spell team, and do not install or use that release
-  * [ ] IF verification failed and no unresolved security issue affects the desired release, run the exact installation command reported by the verifier
-  * [ ] IF installation ran, confirm the installer exit status: exit `0` means installation and verification completed successfully; exit `2` means installation and verification completed successfully but PATH setup is incomplete, so follow the exact export/profile instruction printed by the installer and start or use a shell with that PATH before continuing; any other nonzero exit means installation or verification failed and must be resolved before continuing
-  * [ ] IF installation ran, record the installer output as evidence
-    ```
-    _Insert the complete installer output here_
-    ```
-  * [ ] IF installation ran, rerun the same verifier command and confirm that it exits `0`
-  * [ ] Record the final verifier output as evidence
-    ```
-    _Insert the complete verifier output here_
-    ```
+  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and run `make verify-foundry`
+  * [ ] IF using a force release, record the upstream reference, explicit spell-team approval, and exact release tag, then run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1` instead
+  * [ ] IF verification reports a different desired release, check and record Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice; stop and notify the spell team if an unresolved issue affects that release
+  * [ ] IF verification reports a different desired release and no unresolved issue affects it, run the exact installation command reported by the verifier, then rerun the same verifier command
+  * [ ] Confirm that final verification exits `0` and record the complete verifier output plus installer output IF installation ran
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -42,7 +42,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
-    * [ ] Confirm that the latest verifier reports both the desired release and exact installation command; stop and diagnose any other failure
+    * [ ] Confirm that the latest verifier reports `Required action: install`, the desired release, and the exact installation command; stop and diagnose any other failure
     * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
       ```text
       Desired release:
@@ -58,10 +58,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         Release: vMAJOR.MINOR.PATCH
         ```
     * [ ] IF no unresolved issue affects the release to install, run the exact installation command reported by the latest verifier
-    * IF the installer exits `2`
-      * [ ] Follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-    * [ ] IF the installer exits with any other nonzero status, stop and resolve the failure
-    * [ ] IF installation was performed, rerun the same verifier command, confirm that it exits `0`, and record the complete verifier and installer outputs
+    * [ ] Confirm that the installer succeeds; stop and resolve any failure
+    * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+    * [ ] IF installation was performed, rerun the same verifier command, confirm that it succeeds, and record the complete verifier and installer outputs
       ```text
       Installer output:
       _Insert the complete installer output here_

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -44,21 +44,20 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```
   * OTHERWISE
     * IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-      * [ ] Record the desired release and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+      * [ ] Record the desired release
         ```text
         Desired release: vMAJOR.MINOR.PATCH
+        ```
+      * [ ] Check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+        ```text
         Security sources checked:
         Outstanding issues: None found / _Insert references_
         ```
-      * [ ] Record the complete initial verifier output
-        ```text
-        _Insert the complete initial verifier output here_
-        ```
-    * IF no unresolved issue affects the desired release
-      * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
-        ```text
-        _Insert the complete installer output here_
-        ```
+        * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
+          ```text
+          _Insert the complete installer output here_
+          ```
+        * [ ] OTHERWISE IF an unresolved issue affects the desired release, continue with Exceptional behavior below
       * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
       * [ ] Run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
         ```text

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -36,18 +36,32 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 ## Development Stage
 
 * Verify Foundry tooling
-  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, verify the Foundry binaries currently in PATH
+  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and verify the Foundry binaries currently in PATH
     ```bash
     make verify-foundry
     ```
   * [ ] Confirm the verifier exit status before continuing
-    * Exit `0`: verification completed successfully using the newest stable release published at least seven days ago
-    * Any nonzero exit: verification failed. Install the eligible release before continuing
+    * Exit `0`: verification completed successfully using the newest immutable stable release published at least 14 days ago
+    * Any nonzero exit: verification failed. Use one of the installation paths below before continuing
   * IF verification failed
-    * [ ] Install and verify the eligible Foundry release
-      ```bash
-      make install-foundry
-      ```
+    * Choose one installation path
+      * Default path
+        * [ ] Install and verify the eligible Foundry release
+          ```bash
+          make install-foundry
+          ```
+      * Urgent security-release exception
+        * [ ] Confirm that the release fixes a security issue that cannot wait for the 14-day cooling period
+        * [ ] Record the upstream security advisory or incident reference, the explicit spell-team approval, and the exact release tag
+          ```text
+          Upstream reference:
+          Spell-team approval:
+          Release: vMAJOR.MINOR.PATCH
+          ```
+        * [ ] Install and verify the approved release
+          ```bash
+          make install-foundry release=vMAJOR.MINOR.PATCH
+          ```
     * [ ] Confirm the installer exit status
       * Exit `0`: installation and verification completed successfully
       * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
@@ -56,7 +70,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```
       _Insert the complete installer output here_
       ```
-    * [ ] Run `make verify-foundry` again and confirm that it exits `0`
+    * [ ] Run the verifier matching the selected installation path and confirm that it exits `0`
+      * Default path: `make verify-foundry`
+      * Urgent exception: `make verify-foundry release=vMAJOR.MINOR.PATCH`
   * [ ] Record the final verifier output as evidence
     ```
     _Insert the complete verifier output here_

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -42,7 +42,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
-    * [ ] Confirm that the latest verifier exits `3` and reports both the desired release and exact installation command; stop and diagnose any other result
+    * [ ] Confirm that the latest verifier reports both the desired release and exact installation command; stop and diagnose any other failure
     * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
       ```text
       Desired release:
@@ -57,7 +57,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         Spell-team approval:
         Release: vMAJOR.MINOR.PATCH
         ```
-    * [ ] IF no unresolved issue affects the release to install and the latest verifier exits `3`, run the exact installation command it reported
+    * [ ] IF no unresolved issue affects the release to install, run the exact installation command reported by the latest verifier
     * IF the installer exits `2`
       * [ ] Follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
     * [ ] IF the installer exits with any other nonzero status, stop and resolve the failure

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -42,32 +42,53 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
-    * [ ] Confirm that the latest verifier reports `Required action: install`, the desired release, and the exact installation command; stop and diagnose any other failure
-    * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+    * [ ] IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, record the complete initial verifier output
       ```text
-      Desired release:
+      Initial verifier output:
+      _Insert the complete initial verifier output here_
+      ```
+    * [ ] IF the latest verifier reports `Required action: install`, record the desired release and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+      ```text
+      Desired release: vMAJOR.MINOR.PATCH
       Security sources checked:
       Outstanding issues: None found / _Insert references_
       ```
-    * IF an unresolved issue affects the desired release
-      * [ ] Stop and notify the spell team
-      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference, explicit spell-team approval, and exact release, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, then evaluate its output from the `IF`/`OTHERWISE` decision above
-        ```text
-        Upstream reference:
-        Spell-team approval:
-        Release: vMAJOR.MINOR.PATCH
-        ```
-    * [ ] IF no unresolved issue affects the release to install, run the exact installation command reported by the latest verifier
-    * [ ] Confirm that the installer succeeds; stop and resolve any failure
-    * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-    * [ ] IF installation was performed, rerun the same verifier command, confirm that it succeeds, and record the complete verifier and installer outputs
+    * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
       ```text
       Installer output:
       _Insert the complete installer output here_
-
-      Verifier output:
-      _Insert the complete verifier output here_
       ```
+    * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+    * [ ] IF the installer succeeds, run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
+      ```text
+      Final verifier output:
+      _Insert the complete final verifier output here_
+      ```
+    * Exceptional behavior
+      * [ ] IF the verifier fails without reporting `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, stop and diagnose the failure
+      * IF an unresolved issue affects the desired release
+        * [ ] Stop and notify the spell team
+        * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference, explicit spell-team approval, and exact release, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, and confirm that it either exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`
+          ```text
+          Upstream reference:
+          Spell-team approval:
+          Release: vMAJOR.MINOR.PATCH
+
+          Forced verifier output:
+          _Insert the complete forced verifier output here_
+          ```
+        * [ ] IF the forced verifier reports `Required action: install`, run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that the installer succeeds, and record the complete forced installer output
+          ```text
+          Forced installer output:
+          _Insert the complete forced installer output here_
+          ```
+        * [ ] IF the forced installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+        * [ ] IF forced installation was performed, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it exits `0`, and record the complete final forced verifier output
+          ```text
+          Final forced verifier output:
+          _Insert the complete final forced verifier output here_
+          ```
+      * [ ] IF an installer fails, stop and resolve the failure
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -54,36 +54,40 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         ```text
         _Insert the complete initial verifier output here_
         ```
-    * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
-      ```text
-      _Insert the complete installer output here_
-      ```
-    * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-    * [ ] IF the installer succeeds, run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
-      ```text
-      _Insert the complete final verifier output here_
-      ```
+    * IF no unresolved issue affects the desired release
+      * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
+        ```text
+        _Insert the complete installer output here_
+        ```
+      * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+      * [ ] Run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
+        ```text
+        _Insert the complete final verifier output here_
+        ```
     * Exceptional behavior
       * [ ] IF the verifier fails without reporting `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, stop and diagnose the failure
       * IF an unresolved issue affects the desired release
         * [ ] Stop and notify the spell team
-        * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference, explicit spell-team approval, and exact release, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, and confirm that it either exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`
+        * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, then record the upstream reference, explicit spell-team approval, and exact release
           ```text
           Upstream reference:
           Spell-team approval:
           Release: vMAJOR.MINOR.PATCH
-
+          ```
+        * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it either exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`, and record the complete forced verifier output
+          ```text
           _Insert the complete forced verifier output here_
           ```
-        * [ ] IF the forced verifier reports `Required action: install`, run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that the installer succeeds, and record the complete forced installer output
-          ```text
-          _Insert the complete forced installer output here_
-          ```
-        * [ ] IF the forced installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-        * [ ] IF forced installation was performed, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it exits `0`, and record the complete final forced verifier output
-          ```text
-          _Insert the complete final forced verifier output here_
-          ```
+        * IF the forced verifier reports `Required action: install`
+          * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that the installer succeeds, and record the complete forced installer output
+            ```text
+            _Insert the complete forced installer output here_
+            ```
+          * [ ] IF the forced installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+          * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it exits `0`, and record the complete final forced verifier output
+            ```text
+            _Insert the complete final forced verifier output here_
+            ```
       * [ ] IF an installer fails, stop and resolve the failure
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -38,56 +38,32 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Verify Foundry tooling
   * [ ] Checkout `spells-mainnet` from a trusted, up-to-date source
   * [ ] Run `make verify-foundry`
-  * [ ] IF the latest verifier exits `0`, record the complete verifier output
-    ```text
-    _Insert the complete verifier output here_
-    ```
-  * OTHERWISE
-    * IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-      * [ ] Record the desired release
+  * IF the verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+    * [ ] Record the desired release
+      ```text
+      Desired release: vMAJOR.MINOR.PATCH
+      ```
+    * [ ] Check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+      ```text
+      Security sources checked:
+      Outstanding issues: None found / _Insert references_
+      ```
+    * [ ] IF an unresolved issue affects the desired release, continue with Exceptional behavior below
+    * [ ] OTHERWISE run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that it succeeds, and follow any `Required action: update-path` instructions
+    * [ ] Run `make verify-foundry` and confirm that it exits `0`
+  * Exceptional behavior
+    * [ ] IF the verifier fails without reporting `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, stop and diagnose the failure
+    * IF an unresolved issue affects the desired release
+      * [ ] Stop and notify the spell team
+      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, then record the upstream reference, explicit spell-team approval, and exact release
         ```text
-        Desired release: vMAJOR.MINOR.PATCH
+        Upstream reference:
+        Spell-team approval:
+        Release: vMAJOR.MINOR.PATCH
         ```
-      * [ ] Check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
-        ```text
-        Security sources checked:
-        Outstanding issues: None found / _Insert references_
-        ```
-        * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
-          ```text
-          _Insert the complete installer output here_
-          ```
-        * [ ] OTHERWISE IF an unresolved issue affects the desired release, continue with Exceptional behavior below
-      * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-      * [ ] Run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
-        ```text
-        _Insert the complete final verifier output here_
-        ```
-    * Exceptional behavior
-      * [ ] IF the verifier fails without reporting `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, stop and diagnose the failure
-      * IF an unresolved issue affects the desired release
-        * [ ] Stop and notify the spell team
-        * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, then record the upstream reference, explicit spell-team approval, and exact release
-          ```text
-          Upstream reference:
-          Spell-team approval:
-          Release: vMAJOR.MINOR.PATCH
-          ```
-        * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it either exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`, and record the complete forced verifier output
-          ```text
-          _Insert the complete forced verifier output here_
-          ```
-        * IF the forced verifier reports `Required action: install`
-          * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that the installer succeeds, and record the complete forced installer output
-            ```text
-            _Insert the complete forced installer output here_
-            ```
-          * [ ] IF the forced installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-          * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it exits `0`, and record the complete final forced verifier output
-            ```text
-            _Insert the complete final forced verifier output here_
-            ```
-      * [ ] IF an installer fails, stop and resolve the failure
+      * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1` and confirm that it exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`
+      * [ ] IF installation is required, run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, follow any `Required action: update-path` instructions, rerun the forced verifier, and confirm that it exits `0`
+    * [ ] IF an installer fails, stop and resolve the failure
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -258,9 +258,18 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * [ ] Wait for CI to PASS
 * [ ] Post a comment inside the PR containing:
   * [ ] The final verifier output
+    ```text
+    _Insert the complete verifier output here_
+    ```
   * IF installation was performed
     * [ ] The installer output
-    * [ ] The release asset attestation (from above)
+      ```text
+      _Insert the complete installer output here_
+      ```
+    * [ ] The release asset attestation
+      ```text
+      _Insert the release asset attestation here_
+      ```
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -52,99 +52,95 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete verifier output here_
     ```
-  * IF the verifier fails with `Required action: install` and reports:
-    * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-    * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-    * Review official security sources for the release identified by the verifier
-      * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
+  * IF the verifier exits nonzero, confirm that it reports:
+    * [ ] `Required action: install`
+    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH`
+    * [ ] `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+  * [ ] Record the verifier's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the first candidate release
+  * Review each exact candidate release
+    * Confirm from the candidate's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
+      * [ ] The release is not a draft
+      * [ ] The release is not a prerelease
+      * [ ] The release is marked immutable
+      ```text
+      Release metadata: _Insert exact release URL and outcome_
+      ```
+    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) to confirm that no affected version range includes the candidate
+      ```text
+      Security advisories: _Insert URL and outcome_
+      ```
+    * [ ] Read the candidate's complete [release notes](https://github.com/foundry-rs/foundry/releases) and identify every breaking change
+      ```text
+      Release notes: _Insert exact release URL_
+      Breaking changes: None / _Insert breaking changes_
+      ```
+    * [ ] Determine whether the breaking changes are compatible with spell building, testing, and deployment
+      ```text
+      Compatibility outcome: Compatible / Incompatible
+      ```
+    * [ ] IF a security advisory or the release notes link to a supplemental official advisory or incident notice, read it and determine its applicability and remediation
+      ```text
+      Linked official notices: None / _Insert URLs and applicability or remediation outcomes_
+      ```
+    * [ ] Record whether the candidate is acceptable
+      ```text
+      Candidate release: vMAJOR.MINOR.PATCH
+      Outcome: Acceptable / Affected / Applicability unclear / Incompatible
+      ```
+  * IF the candidate is affected, its applicability is unclear, or it has an incompatible breaking change
+    * [ ] Notify the spell team
+    * [ ] Identify an exact alternative release, either older or newer
+    * [ ] Locate an official upstream reference showing that the alternative is unaffected or addresses the issue
+    * [ ] Repeat the exact candidate-release review above for the alternative
+  * IF an alternative release is selected
+    * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
+    * [ ] Obtain explicit spell-team approval in a reply to that comment or another spell PR comment
+  * [ ] Confirm that the selected candidate has an `Acceptable` review outcome
+  * [ ] Compare the selected candidate with the current CI Foundry release
+  * [ ] IF the selected candidate differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
+  * [ ] IF the selected candidate is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
+  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in `.github/workflows/tests.yaml`
+  * [ ] IF no cooling-period waiver applies, remove `ignore-age=1` from both Foundry commands in `.github/workflows/tests.yaml`
+  * [ ] Confirm that both CI commands use the same release and age-waiver arguments
+  * The CI release remains pinned until a later approved release replaces it
+  * [ ] IF the selected candidate is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
+    ```text
+    _Insert the complete verifier output here_
+    ```
+  * [ ] OTHERWISE IF the selected candidate is less than 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
+    ```text
+    _Insert the complete verifier output here_
+    ```
+  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the selected candidate
+  * OTHERWISE IF the exact-release verifier fails with `Required action: install` and reports:
+    * `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the selected candidate
+    * `Installation command:` matching the selected candidate and including `ignore-age=1` when the cooling period is waived
+    * [ ] Run the exact `Installation command` printed by the verifier
+      ```text
+      _Insert the complete installer output here_
+      ```
+    * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+    * IF the installer exits `0`
+      * [ ] Rerun the same exact-release verifier
         ```text
-        Checked at (UTC):
-        Security advisories: _Insert URL and outcome_
+        _Insert the complete verifier output here_
         ```
-      * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the release
-        ```text
-        Checked at (UTC):
-        Release notes: _Insert exact release URL and outcome_
-        ```
-      * [ ] Review every official advisory or incident notice linked from either source for applicability to the desired release
-        ```text
-        Checked at (UTC):
-        Linked official notices: None / _Insert URLs and outcomes_
-        ```
-      * [ ] IF applicability is unresolved or unclear, treat the release as affected
-    * IF the security review finds no unresolved issue affecting the desired release
-      * [ ] Run the exact `Installation command` printed by the verifier
-        ```text
-        _Insert the complete installer output here_
-        ```
-      * IF the installer succeeds
-        * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-        * [ ] Run `make verify-foundry`
-          ```text
-          _Insert the complete verifier output here_
-          ```
-        * [ ] Confirm that the verifier exits `0`
-    * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the desired release
-      * [ ] Notify the spell team
-      * [ ] Identify an exact mitigation release
-      * [ ] Locate an official upstream reference showing that the mitigation release addresses the issue
-      * Review official security sources for the mitigation release
-        * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the mitigation release
-          ```text
-          Checked at (UTC):
-          Security advisories: _Insert URL and outcome_
-          ```
-        * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the mitigation release
-          ```text
-          Checked at (UTC):
-          Release notes: _Insert exact release URL and outcome_
-          ```
-        * [ ] Review every official advisory or incident notice linked from either source for applicability to the mitigation release
-          ```text
-          Checked at (UTC):
-          Linked official notices: None / _Insert URLs and outcomes_
-          ```
-        * [ ] IF applicability is unresolved or unclear, treat the mitigation release as affected
-      * IF the security review finds no unresolved issue affecting the mitigation release
-        * [ ] Obtain explicit spell-team approval for the mitigation release
-          ```text
-          Upstream reference:
-          Spell-team approval:
-          Release: vMAJOR.MINOR.PATCH
-          ```
-        * [ ] IF the mitigation release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
-          ```text
-          _Insert the complete verifier output here_
-          ```
-        * OTHERWISE IF the mitigation release is less than 14 days old
-          * [ ] Confirm that the spell-team approval explicitly waives the 14-day cooling period
-          * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
-            ```text
-            _Insert the complete verifier output here_
-            ```
-        * IF the exact-release verifier fails with `Required action: install` for the mitigation release and reports:
-          * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-          * `Installation command:` matching the mitigation release and including `ignore-age=1` when the cooling period is waived
-          * [ ] Run the exact printed `Installation command`
-            ```text
-            _Insert the complete installer output here_
-            ```
-          * IF the installer succeeds
-            * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-            * [ ] Rerun the same exact-release verifier
-              ```text
-              _Insert the complete verifier output here_
-              ```
-            * [ ] Confirm that the verifier exits `0`
-      * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the mitigation release
-        * [ ] Stop the workflow
-  * IF either `make verify-foundry` or `make install-foundry` exits nonzero without printing all of:
-    * `Required action: install`
-    * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-    * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when the cooling period is waived
-    * [ ] Stop the workflow
+      * [ ] Confirm that the verifier exits `0`
+  * IF either unexpected Foundry setup failure occurs:
+    * A `make verify-foundry` invocation exits nonzero without:
+      * `Required action: install`
+      * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+      * `Installation command:` matching the desired release and including `ignore-age=1` when the cooling period is waived
+    * A `make install-foundry` invocation exits nonzero
+    * [ ] Record the failed command and complete output in the spell PR
+    * [ ] Stop Foundry setup
     * [ ] Diagnose the failure
     * [ ] Resolve the failure
+    * [ ] Rerun the exact failed command
+      ```text
+      _Insert the complete command output here_
+      ```
+    * [ ] IF the failure cannot be resolved, notify the spell team
 * Cleanup previous spell's actions
   * [ ] Check previous pull requests for the cleanup patterns
   * [ ] Delete unused dependencies in the `src/dependencies` folder IF applicable

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -38,6 +38,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Verify Foundry tooling
   * [ ] Checkout `spells-mainnet` from a trusted, up-to-date source
   * [ ] Run `make verify-foundry`
+    ```text
+    _Insert the complete verifier output here_
+    ```
   * IF the verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
     * [ ] Record the desired release
       ```text

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -41,34 +41,74 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete verifier output here_
     ```
-  * IF the verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-    * [ ] Record the desired release
-      ```text
-      Desired release: vMAJOR.MINOR.PATCH
-      ```
-    * [ ] Check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
-      ```text
-      Security sources checked:
-      Outstanding issues: None found / _Insert references_
-      ```
-    * [ ] IF an unresolved issue affects the desired release, continue with Exceptional behavior below
-    * [ ] OTHERWISE run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that it succeeds, and follow any `Required action: update-path` instructions
-    * [ ] Run `make verify-foundry` and confirm that it exits `0`
-  * Exceptional behavior
-    * [ ] IF the verifier fails without reporting `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, stop and diagnose the failure
-    * IF an unresolved issue affects the desired release
-      * [ ] Stop and notify the spell team
-      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, then record the upstream reference, explicit spell-team approval, and exact release
+  * IF the verifier fails
+    * IF any of these verifier output lines is missing:
+      * `Required action: install`
+      * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+      * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+      * [ ] Stop the workflow
+      * [ ] Diagnose the verifier failure
+    * OTHERWISE IF the failed verifier requires installation and reports both the desired release and its exact installation command
+      * Review official security sources for the release identified by the verifier
+        * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
+        * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the release
+        * [ ] Open every official advisory or incident notice linked from either source
+        * [ ] Read every linked official advisory or incident notice
+        * [ ] Determine whether each advisory or notice affects the release
+        * [ ] IF applicability is unresolved or unclear, treat the release as affected
         ```text
-        Upstream reference:
-        Spell-team approval:
-        Release: vMAJOR.MINOR.PATCH
+        Checked at (UTC):
+        Security advisories: _Insert URL and outcome_
+        Release notes: _Insert exact release URL and outcome_
+        Linked official notices: None / _Insert URLs and outcomes_
         ```
-      * [ ] IF the mitigation release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
-      * [ ] OTHERWISE confirm that the spell-team approval explicitly waives the 14-day cooling period, then run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
-      * [ ] Confirm that the exact-release verifier exits `0` or reports `Required action: install` and an exact `Installation command`
-      * [ ] IF installation is required, run the exact printed `Installation command`, follow any `Required action: update-path` instructions, rerun the same exact-release verifier, and confirm that it exits `0`
-    * [ ] IF an installer fails, stop and resolve the failure
+      * IF none of the checked sources identifies an unresolved issue affecting the desired release
+        * [ ] Run the exact `Installation command` printed by the verifier
+        * IF the installer fails
+          * [ ] Stop the workflow
+          * [ ] Resolve the installer failure
+        * OTHERWISE IF the installer succeeds
+          * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+          * [ ] Run `make verify-foundry`
+          * [ ] Confirm that the verifier exits `0`
+      * OTHERWISE IF the checked sources identify an unresolved issue affecting the desired release
+        * [ ] Stop the workflow
+        * [ ] Notify the spell team
+        * [ ] Identify an exact mitigation release
+        * [ ] Locate an official upstream reference showing that the mitigation release addresses the issue
+        * Review official security sources for the mitigation release
+          * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the mitigation release
+          * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the mitigation release
+          * [ ] Open every official advisory or incident notice linked from either source
+          * [ ] Read every linked official advisory or incident notice
+          * [ ] Determine whether each advisory or notice affects the mitigation release
+          * [ ] IF applicability is unresolved or unclear, treat the mitigation release as affected
+        * [ ] Obtain explicit spell-team approval for the mitigation release
+          ```text
+          Upstream reference:
+          Spell-team approval:
+          Release: vMAJOR.MINOR.PATCH
+          ```
+        * [ ] IF the mitigation release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
+        * OTHERWISE IF the mitigation release is less than 14 days old
+          * [ ] Confirm that the spell-team approval explicitly waives the 14-day cooling period
+          * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
+        * IF the exact-release verifier fails
+          * IF any of these exact-release verifier output requirements is missing:
+            * `Required action: install`
+            * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+            * `Installation command:` matching the mitigation release and including `ignore-age=1` when the cooling period is waived
+            * [ ] Stop the workflow
+            * [ ] Diagnose the verifier failure
+          * OTHERWISE IF the failed exact-release verifier requires installation for the mitigation release and prints a matching installation command
+            * [ ] Run the exact printed `Installation command`
+            * IF the installer fails
+              * [ ] Stop the workflow
+              * [ ] Resolve the installer failure
+            * OTHERWISE IF the installer succeeds
+              * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+              * [ ] Rerun the same exact-release verifier
+              * [ ] Confirm that the verifier exits `0`
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -35,8 +35,19 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 ## Development Stage
 
-* Verify Foundry tooling
-  * [ ] Checkout `spells-mainnet` from a trusted, up-to-date source
+* Prepare the `spells-mainnet` checkout
+  * [ ] Pull the `master` branch of a trusted local copy of the [`sky-ecosystem/spells-mainnet` repository](https://github.com/sky-ecosystem/spells-mainnet)
+    ```bash
+    git switch master
+    git pull --ff-only origin master
+    ```
+  * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell
+* Verify and Install Foundry toolkit
+  * [ ] Record the exact Foundry release and optional age waiver used by both `make install-foundry` and `make verify-foundry` in `.github/workflows/tests.yaml`
+    ```text
+    CI Foundry release: vMAJOR.MINOR.PATCH
+    CI age waiver: None / ignore-age=1
+    ```
   * [ ] Run `make verify-foundry`
     ```text
     _Insert the complete verifier output here_
@@ -134,9 +145,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Stop the workflow
     * [ ] Diagnose the failure
     * [ ] Resolve the failure
-* Create new branch
-  * [ ] Pull `master` branch of the `spells-mainnet` repo locally
-  * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell
 * Cleanup previous spell's actions
   * [ ] Check previous pull requests for the cleanup patterns
   * [ ] Delete unused dependencies in the `src/dependencies` folder IF applicable

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -35,7 +35,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 ## Development Stage
 
-* Install stable Foundry version
+* Install Foundry tooling
+  * [ ] Install the latest version of `foundryup` using one of the methods described in the official [Foundry installation docs](https://www.getfoundry.sh/introduction/installation)
   * [ ] Install the stable version of Foundry via `foundryup --install stable`
     ```
     Document the installation logs containing installed versions below:

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -36,7 +36,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 ## Development Stage
 
 * Verify Foundry tooling
-  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and run `make verify-foundry`
+  * [ ] Checkout `spells-mainnet` from a trusted, up-to-date source
+  * [ ] Run `make verify-foundry`
   * [ ] IF the latest verifier exits `0`, record the complete verifier output
     ```text
     _Insert the complete verifier output here_
@@ -44,7 +45,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * OTHERWISE
     * [ ] IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, record the complete initial verifier output
       ```text
-      Initial verifier output:
       _Insert the complete initial verifier output here_
       ```
     * [ ] IF the latest verifier reports `Required action: install`, record the desired release and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
@@ -55,13 +55,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```
     * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
       ```text
-      Installer output:
       _Insert the complete installer output here_
       ```
     * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
     * [ ] IF the installer succeeds, run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
       ```text
-      Final verifier output:
       _Insert the complete final verifier output here_
       ```
     * Exceptional behavior
@@ -74,18 +72,15 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
           Spell-team approval:
           Release: vMAJOR.MINOR.PATCH
 
-          Forced verifier output:
           _Insert the complete forced verifier output here_
           ```
         * [ ] IF the forced verifier reports `Required action: install`, run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that the installer succeeds, and record the complete forced installer output
           ```text
-          Forced installer output:
           _Insert the complete forced installer output here_
           ```
         * [ ] IF the forced installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
         * [ ] IF forced installation was performed, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it exits `0`, and record the complete final forced verifier output
           ```text
-          Final forced verifier output:
           _Insert the complete final forced verifier output here_
           ```
       * [ ] IF an installer fails, stop and resolve the failure

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -36,43 +36,44 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 ## Development Stage
 
 * Verify Foundry tooling
-  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and verify the Foundry binaries currently in PATH
+  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md)
+  * [ ] IF using the normal release policy, verify the Foundry binaries currently in PATH
     ```bash
     make verify-foundry
     ```
-  * [ ] Confirm the verifier exit status before continuing
-    * Exit `0`: verification completed successfully using the newest immutable stable release published at least 14 days ago
-    * Any nonzero exit: verification failed. Use one of the installation paths below before continuing
-  * IF verification failed
-    * Choose one installation path
-      * Default path
-        * [ ] Install and verify the eligible Foundry release
-          ```bash
-          make install-foundry
-          ```
-      * Urgent security-release exception
-        * [ ] Confirm that the release fixes a security issue that cannot wait for the 14-day cooling period
-        * [ ] Record the upstream security advisory or incident reference, the explicit spell-team approval, and the exact release tag
-          ```text
-          Upstream reference:
-          Spell-team approval:
-          Release: vMAJOR.MINOR.PATCH
-          ```
-        * [ ] Install and verify the approved release
-          ```bash
-          make install-foundry release=vMAJOR.MINOR.PATCH
-          ```
-    * [ ] Confirm the installer exit status
-      * Exit `0`: installation and verification completed successfully
-      * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
-      * Any other nonzero exit: installation or verification failed. Resolve the failure before continuing
-    * [ ] Record the installer output as evidence
-      ```
-      _Insert the complete installer output here_
-      ```
-    * [ ] Run the verifier matching the selected installation path and confirm that it exits `0`
-      * Default path: `make verify-foundry`
-      * Urgent exception: `make verify-foundry release=vMAJOR.MINOR.PATCH`
+  * [ ] IF using a force release that cannot wait for the 14-day cooling period, confirm that it fixes an urgent security issue and record the upstream reference, explicit spell-team approval, and exact release tag
+    ```text
+    Upstream reference:
+    Spell-team approval:
+    Release: vMAJOR.MINOR.PATCH
+    ```
+  * [ ] IF using a force release, verify the approved release instead of running the normal verifier command
+    ```bash
+    make verify-foundry release=vMAJOR.MINOR.PATCH force=1
+    ```
+  * [ ] Confirm the verifier exit status. Exit `0` means the installed release matches the desired release and no installation checks are required. Any nonzero exit means verification failed; continue only if the output reports a desired release and exact installation command, otherwise resolve the failure before continuing
+  * [ ] IF verification failed, record the desired release and installation command reported by the verifier
+    ```text
+    Desired install version:
+    Published at:
+    Release URL:
+    Installation command:
+    ```
+  * [ ] IF verification failed, check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the desired release's official notes, and any official incident notice linked from those sources for unresolved security issues affecting that release
+  * [ ] IF verification failed, record the version-specific security check as evidence
+    ```text
+    Checked at (UTC):
+    Sources checked:
+    Outstanding issues affecting the desired version: None found / _Insert references_
+    ```
+  * [ ] IF an unresolved security issue affects the desired release, stop, notify the spell team, and do not install or use that release
+  * [ ] IF verification failed and no unresolved security issue affects the desired release, run the exact installation command reported by the verifier
+  * [ ] IF installation ran, confirm the installer exit status: exit `0` means installation and verification completed successfully; exit `2` means installation and verification completed successfully but PATH setup is incomplete, so follow the exact export/profile instruction printed by the installer and start or use a shell with that PATH before continuing; any other nonzero exit means installation or verification failed and must be resolved before continuing
+  * [ ] IF installation ran, record the installer output as evidence
+    ```
+    _Insert the complete installer output here_
+    ```
+  * [ ] IF installation ran, rerun the same verifier command and confirm that it exits `0`
   * [ ] Record the final verifier output as evidence
     ```
     _Insert the complete verifier output here_

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -41,42 +41,60 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete verifier output here_
     ```
-  * IF the verifier fails
-    * IF the failed verifier requires installation and reports all of:
-      * `Required action: install`
-      * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-      * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-      * Review official security sources for the release identified by the verifier
-        * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
-        * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the release
-        * [ ] Open every official advisory or incident notice linked from either source
-        * [ ] Read every linked official advisory or incident notice
-        * [ ] Determine whether each advisory or notice affects the release
-        * [ ] IF applicability is unresolved or unclear, treat the release as affected
+  * IF the verifier fails with `Required action: install` and reports:
+    * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+    * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+    * Review official security sources for the release identified by the verifier
+      * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
         ```text
         Checked at (UTC):
         Security advisories: _Insert URL and outcome_
+        ```
+      * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the release
+        ```text
+        Checked at (UTC):
         Release notes: _Insert exact release URL and outcome_
+        ```
+      * [ ] Review every official advisory or incident notice linked from either source for applicability to the desired release
+        ```text
+        Checked at (UTC):
         Linked official notices: None / _Insert URLs and outcomes_
         ```
-      * IF none of the checked sources identifies an unresolved issue affecting the desired release
-        * [ ] Run the exact `Installation command` printed by the verifier
-        * IF the installer succeeds
-          * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-          * [ ] Run `make verify-foundry`
-          * [ ] Confirm that the verifier exits `0`
-      * OTHERWISE IF the checked sources identify an unresolved issue affecting the desired release
-        * [ ] Stop the workflow
-        * [ ] Notify the spell team
-        * [ ] Identify an exact mitigation release
-        * [ ] Locate an official upstream reference showing that the mitigation release addresses the issue
-        * Review official security sources for the mitigation release
-          * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the mitigation release
-          * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the mitigation release
-          * [ ] Open every official advisory or incident notice linked from either source
-          * [ ] Read every linked official advisory or incident notice
-          * [ ] Determine whether each advisory or notice affects the mitigation release
-          * [ ] IF applicability is unresolved or unclear, treat the mitigation release as affected
+      * [ ] IF applicability is unresolved or unclear, treat the release as affected
+    * IF the security review finds no unresolved issue affecting the desired release
+      * [ ] Run the exact `Installation command` printed by the verifier
+        ```text
+        _Insert the complete installer output here_
+        ```
+      * IF the installer succeeds
+        * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+        * [ ] Run `make verify-foundry`
+          ```text
+          _Insert the complete verifier output here_
+          ```
+        * [ ] Confirm that the verifier exits `0`
+    * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the desired release
+      * [ ] Notify the spell team
+      * [ ] Identify an exact mitigation release
+      * [ ] Locate an official upstream reference showing that the mitigation release addresses the issue
+      * Review official security sources for the mitigation release
+        * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the mitigation release
+          ```text
+          Checked at (UTC):
+          Security advisories: _Insert URL and outcome_
+          ```
+        * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the mitigation release
+          ```text
+          Checked at (UTC):
+          Release notes: _Insert exact release URL and outcome_
+          ```
+        * [ ] Review every official advisory or incident notice linked from either source for applicability to the mitigation release
+          ```text
+          Checked at (UTC):
+          Linked official notices: None / _Insert URLs and outcomes_
+          ```
+        * [ ] IF applicability is unresolved or unclear, treat the mitigation release as affected
+      * IF the security review finds no unresolved issue affecting the mitigation release
         * [ ] Obtain explicit spell-team approval for the mitigation release
           ```text
           Upstream reference:
@@ -84,20 +102,32 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
           Release: vMAJOR.MINOR.PATCH
           ```
         * [ ] IF the mitigation release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
+          ```text
+          _Insert the complete verifier output here_
+          ```
         * OTHERWISE IF the mitigation release is less than 14 days old
           * [ ] Confirm that the spell-team approval explicitly waives the 14-day cooling period
           * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
-        * IF the exact-release verifier fails
-          * IF the failed exact-release verifier requires installation for the mitigation release and reports all of:
-            * `Required action: install`
-            * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-            * `Installation command:` matching the mitigation release and including `ignore-age=1` when the cooling period is waived
-            * [ ] Run the exact printed `Installation command`
-            * IF the installer succeeds
-              * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-              * [ ] Rerun the same exact-release verifier
-              * [ ] Confirm that the verifier exits `0`
-  * IF any `setup-foundry.sh` invocation exits nonzero without printing all of:
+            ```text
+            _Insert the complete verifier output here_
+            ```
+        * IF the exact-release verifier fails with `Required action: install` for the mitigation release and reports:
+          * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+          * `Installation command:` matching the mitigation release and including `ignore-age=1` when the cooling period is waived
+          * [ ] Run the exact printed `Installation command`
+            ```text
+            _Insert the complete installer output here_
+            ```
+          * IF the installer succeeds
+            * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+            * [ ] Rerun the same exact-release verifier
+              ```text
+              _Insert the complete verifier output here_
+              ```
+            * [ ] Confirm that the verifier exits `0`
+      * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the mitigation release
+        * [ ] Stop the workflow
+  * IF either `make verify-foundry` or `make install-foundry` exits nonzero without printing all of:
     * `Required action: install`
     * `Desired Foundry release: vMAJOR.MINOR.PATCH`
     * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when the cooling period is waived
@@ -302,11 +332,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete verifier output here_
     ```
-  * IF installation was performed
-    * [ ] The complete output of the last `make install-foundry release={vX.Y.Z}` executed
-      ```text
-      _Insert the complete installer output here_
-      ```
+  * [ ] IF installation was performed, include the complete output from the last execution of the exact `Installation command` printed by the verifier
+    ```text
+    _Insert the complete installer output here_
+    ```
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -36,29 +36,20 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 ## Development Stage
 
 * Install Foundry tooling
-  * [ ] Install the latest version of `foundryup` using one of the methods described in the official [Foundry installation docs](https://www.getfoundry.sh/introduction/installation)
-  * [ ] Install the stable Foundry version via `foundryup --install stable`
-    ```
-    Document the installed version below:
-    ```
-    * [ ] Check the `Build Timestamp` shown by `forge --version`
-      ```
-      Document the build timestamp below:
-      ```
-    * [ ] IF the installed stable version is less than 7 days old, install the previous stable version from the official [Foundry releases page](https://github.com/foundry-rs/foundry/releases) via `foundryup --install <version>`
-      ```
-      Document the selected release URL if pinning was needed below:
-      ```
-    * [ ] Do not use `foundryup --force`
-  * [ ] Verify attestations for the final installed Foundry binaries
+  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, install and verify Foundry
     ```bash
-    for bin in forge cast anvil chisel; do
-      gh attestation verify --owner foundry-rs "$(which "$bin")"
-    done
+    make install-foundry
     ```
-    ```
-    Document the attestation verification output below:
-    ```
+  * [ ] Confirm the installer exit status before continuing
+    * Exit `0`: installation and verification completed successfully
+    * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
+    * Any other nonzero exit: installation or verification failed. Resolve the failure before continuing
+  * [ ] Record the installer output as evidence:
+    * `spells-mainnet` source commit and installer SHA-256
+    * Selected Foundry release tag, publication timestamp, URL, and seven-day policy decision
+    * Archive attestation
+    * Installed versions
+    * Attestations for `forge`, `cast`, `anvil`, and `chisel`
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell
@@ -253,7 +244,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
 * [ ] Post a comment inside the PR containing:
-  * Foundry installation logs containing installed versions (from above)
+  * The `spells-mainnet` source commit and installer SHA-256; selected Foundry release tag, publication timestamp, URL, and seven-day policy decision; archive attestation; installed versions; and attestations for `forge`, `cast`, `anvil`, and `chisel` (from above)
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -37,11 +37,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 * Verify Foundry tooling
   * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and run `make verify-foundry`
-  * [ ] IF verification exits `0`, record the complete verifier output
+  * [ ] IF the latest verifier exits `0`, record the complete verifier output
     ```text
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
+    * [ ] Confirm that the latest verifier exits `3` and reports both the desired release and exact installation command; stop and diagnose any other result
     * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
       ```text
       Desired release:
@@ -50,14 +51,17 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```
     * IF an unresolved issue affects the desired release
       * [ ] Stop and notify the spell team
-      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference and explicit spell-team approval, then run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`
+      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference, explicit spell-team approval, and exact release, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, then evaluate its output from the `IF`/`OTHERWISE` decision above
         ```text
         Upstream reference:
         Spell-team approval:
         Release: vMAJOR.MINOR.PATCH
         ```
-    * [ ] IF no unresolved issue affects the release to install, run the exact installation command reported by the applicable verifier
-    * [ ] Rerun the same verifier command, confirm that it exits `0`, and record the complete verifier and installer outputs
+    * [ ] IF no unresolved issue affects the release to install and the latest verifier exits `3`, run the exact installation command it reported
+    * IF the installer exits `2`
+      * [ ] Follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+    * [ ] IF the installer exits with any other nonzero status, stop and resolve the failure
+    * [ ] IF installation was performed, rerun the same verifier command, confirm that it exits `0`, and record the complete verifier and installer outputs
       ```text
       Installer output:
       _Insert the complete installer output here_
@@ -264,13 +268,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete verifier output here_
     ```
   * IF installation was performed
-    * [ ] The installer output
+    * [ ] The complete installer output, including the release asset attestation
       ```text
       _Insert the complete installer output here_
-      ```
-    * [ ] The release asset attestation
-      ```text
-      _Insert the release asset attestation here_
       ```
   * A link to the deployed spell
   * A link to the created Tenderly Testnet

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -37,24 +37,26 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 * Verify Foundry tooling
   * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and run `make verify-foundry`
-  * [ ] IF using a force release, record the upstream reference, explicit spell-team approval, and exact release tag, then run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1` instead
-    ```text
-    Upstream reference:
-    Spell-team approval:
-    Release: vMAJOR.MINOR.PATCH
-    ```
   * [ ] IF verification exits `0`, record the complete verifier output
     ```text
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
-    * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice; stop and notify the spell team if an unresolved issue affects that release
+    * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
       ```text
       Desired release:
       Security sources checked:
       Outstanding issues: None found / _Insert references_
       ```
-    * [ ] IF no unresolved issue affects the desired release, run the exact installation command reported by the verifier
+    * IF an unresolved issue affects the desired release
+      * [ ] Stop and notify the spell team
+      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference and explicit spell-team approval, then run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`
+        ```text
+        Upstream reference:
+        Spell-team approval:
+        Release: vMAJOR.MINOR.PATCH
+        ```
+    * [ ] IF no unresolved issue affects the release to install, run the exact installation command reported by the applicable verifier
     * [ ] Rerun the same verifier command, confirm that it exits `0`, and record the complete verifier and installer outputs
       ```text
       Installer output:

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -35,18 +35,31 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 ## Development Stage
 
-* Install Foundry tooling
-  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, install and verify Foundry
+* Verify Foundry tooling
+  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, verify the Foundry binaries currently in PATH
     ```bash
-    make install-foundry
+    make verify-foundry
     ```
-  * [ ] Confirm the installer exit status before continuing
-    * Exit `0`: installation and verification completed successfully
-    * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
-    * Any other nonzero exit: installation or verification failed. Resolve the failure before continuing
-  * [ ] Record the installer output as evidence:
+  * [ ] Confirm the verifier exit status before continuing
+    * Exit `0`: verification completed successfully using the newest stable release published at least seven days ago
+    * Any nonzero exit: verification failed. Install the eligible release before continuing
+  * IF verification failed
+    * [ ] Install and verify the eligible Foundry release
+      ```bash
+      make install-foundry
+      ```
+    * [ ] Confirm the installer exit status
+      * Exit `0`: installation and verification completed successfully
+      * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
+      * Any other nonzero exit: installation or verification failed. Resolve the failure before continuing
+    * [ ] Record the installer output as evidence
+      ```
+      _Insert the complete installer output here_
+      ```
+    * [ ] Run `make verify-foundry` again and confirm that it exits `0`
+  * [ ] Record the final verifier output as evidence
     ```
-    _Insert the complete installer output here_
+    _Insert the complete verifier output here_
     ```
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
@@ -242,7 +255,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
 * [ ] Post a comment inside the PR containing:
-  * The `spells-mainnet` source commit and installer SHA-256; selected Foundry release tag, publication timestamp, URL, and seven-day policy decision; archive attestation; installed versions; and attestations for `forge`, `cast`, `anvil`, and `chisel` (from above)
+  * The final verifier output and, IF installation was performed, the installer output including the release asset attestation (from above)
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -283,12 +283,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
 * [ ] Post a comment inside the PR containing:
-  * [ ] The final verifier output
+  * [ ] The output of the last `make verify-foundry` executed
     ```text
     _Insert the complete verifier output here_
     ```
   * IF installation was performed
-    * [ ] The complete installer output, including the release asset attestation
+    * [ ] The complete output of the last `make install-foundry release={vX.Y.Z}` executed
       ```text
       _Insert the complete installer output here_
       ```

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -37,9 +37,27 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 * Install Foundry tooling
   * [ ] Install the latest version of `foundryup` using one of the methods described in the official [Foundry installation docs](https://www.getfoundry.sh/introduction/installation)
-  * [ ] Install the stable version of Foundry via `foundryup --install stable`
+  * [ ] Install the stable Foundry version via `foundryup --install stable`
     ```
-    Document the installation logs containing installed versions below:
+    Document the installed version below:
+    ```
+    * [ ] Check the `Build Timestamp` shown by `forge --version`
+      ```
+      Document the build timestamp below:
+      ```
+    * [ ] IF the installed stable version is less than 7 days old, install the previous stable version from the official [Foundry releases page](https://github.com/foundry-rs/foundry/releases) via `foundryup --install <version>`
+      ```
+      Document the selected release URL if pinning was needed below:
+      ```
+    * [ ] Do not use `foundryup --force`
+  * [ ] Verify attestations for the final installed Foundry binaries
+    ```bash
+    for bin in forge cast anvil chisel; do
+      gh attestation verify --owner foundry-rs "$(which "$bin")"
+    done
+    ```
+    ```
+    Document the attestation verification output below:
     ```
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -43,16 +43,17 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
-    * [ ] IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, record the complete initial verifier output
-      ```text
-      _Insert the complete initial verifier output here_
-      ```
-    * [ ] IF the latest verifier reports `Required action: install`, record the desired release and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
-      ```text
-      Desired release: vMAJOR.MINOR.PATCH
-      Security sources checked:
-      Outstanding issues: None found / _Insert references_
-      ```
+    * IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+      * [ ] Record the desired release and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+        ```text
+        Desired release: vMAJOR.MINOR.PATCH
+        Security sources checked:
+        Outstanding issues: None found / _Insert references_
+        ```
+      * [ ] Record the complete initial verifier output
+        ```text
+        _Insert the complete initial verifier output here_
+        ```
     * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
       ```text
       _Insert the complete installer output here_

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -45,11 +45,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
     * Any other nonzero exit: installation or verification failed. Resolve the failure before continuing
   * [ ] Record the installer output as evidence:
-    * `spells-mainnet` source commit and installer SHA-256
-    * Selected Foundry release tag, publication timestamp, URL, and seven-day policy decision
-    * Archive attestation
-    * Installed versions
-    * Attestations for `forge`, `cast`, `anvil`, and `chisel`
+    ```
+    _Insert the complete installer output here_
+    ```
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -64,8 +64,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         Spell-team approval:
         Release: vMAJOR.MINOR.PATCH
         ```
-      * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1` and confirm that it exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`
-      * [ ] IF installation is required, run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, follow any `Required action: update-path` instructions, rerun the forced verifier, and confirm that it exits `0`
+      * [ ] IF the mitigation release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
+      * [ ] OTHERWISE confirm that the spell-team approval explicitly waives the 14-day cooling period, then run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
+      * [ ] Confirm that the exact-release verifier exits `0` or reports `Required action: install` and an exact `Installation command`
+      * [ ] IF installation is required, run the exact printed `Installation command`, follow any `Required action: update-path` instructions, rerun the same exact-release verifier, and confirm that it exits `0`
     * [ ] IF an installer fails, stop and resolve the failure
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -257,7 +257,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
 * [ ] Post a comment inside the PR containing:
-  * The final verifier output and, IF installation was performed, the installer output including the release asset attestation (from above)
+  * [ ] The final verifier output
+  * IF installation was performed
+    * [ ] The installer output
+    * [ ] The release asset attestation (from above)
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -313,6 +313,14 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * Check local env
     * [ ] `cast wallet address --keystore $ETH_KEYSTORE` shows the deployer address
     * [ ] `cast chain-id` shows `1` for Mainnet
+* Verify the CI-pinned Foundry release
+  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when it is present in CI
+    ```text
+    _Insert the complete verifier output here_
+    ```
+  * [ ] Confirm that the verifier exits `0`
+  * [ ] Confirm that the desired and installed releases match the release pinned in CI
+  * [ ] Post the exact command and complete output in the spell PR before deployment
 * Deploy spell on mainnet
   * [ ] `make deploy`
   * Ensure `src/test/config.sol` is edited correctly
@@ -332,14 +340,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
 * [ ] Post a comment inside the PR containing:
-  * [ ] The output of the last `make verify-foundry` executed
-    ```text
-    _Insert the complete verifier output here_
-    ```
-  * [ ] IF installation was performed, include the complete output from the last execution of the exact `Installation command` printed by the verifier
-    ```text
-    _Insert the complete installer output here_
-    ```
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -43,7 +43,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell
 * Verify and Install Foundry toolkit
-  * [ ] Record the workflow-level Foundry settings from [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml)
+  * [ ] Record the workflow-level Foundry settings from [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
     ```text
     FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
     FOUNDRY_IGNORE_AGE: 0 / 1
@@ -100,9 +100,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Both spell reviewers reply to that comment with explicit approval
   * [ ] Confirm that the selected release has an `Acceptable` review outcome
   * [ ] Compare the selected release with the current `FOUNDRY_RELEASE`
-  * [ ] IF the selected release differs from the CI release, update `FOUNDRY_RELEASE` in [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml)
+  * [ ] IF the selected release differs from the CI release, update `FOUNDRY_RELEASE` in [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
   * [ ] IF the selected release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] IF the cooling-period waiver applies, set `FOUNDRY_IGNORE_AGE` to `"1"` in [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml); OTHERWISE set it to `"0"`
+  * [ ] IF the cooling-period waiver applies, set `FOUNDRY_IGNORE_AGE` to `"1"` in [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml); OTHERWISE set it to `"0"`
   * [ ] Confirm that `make install-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
   * [ ] Confirm that `make verify-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
   * [ ] IF the selected release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -54,10 +54,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       FOUNDRY_IGNORE_AGE: 0 / 1
       ```
     * [ ] Treat the selected release as the release under review
-    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the release under review
+    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release under review
+    * [ ] IF an applicable advisory links an official Foundry incident notice, review that notice for unresolved issues affecting the release
       ```text
       Security review: Unaffected / Affected / Applicability unclear
-      Sources and rationale: None affecting the release / _Insert URLs and outcome_
+      Security advisories: _Insert URLs and outcome_
+      Linked incident notices: None / _Insert URLs and outcome_
       ```
     * [ ] IF adopting the release under review changes the workflow-level `FOUNDRY_RELEASE`, read its complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
       ```text

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -97,7 +97,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Repeat the exact release review above for the alternative
   * IF an alternative release is selected
     * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
-    * [ ] Obtain explicit spell-team approval in a reply to that comment or another spell PR comment
+    * [ ] Both spell reviewers reply to that comment with explicit approval
   * [ ] Confirm that the selected release has an `Acceptable` review outcome
   * [ ] Compare the selected release with the current CI Foundry release
   * [ ] IF the selected release differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
@@ -310,7 +310,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```
   * [ ] Confirm that the verifier exits `0`
   * [ ] Confirm that the desired and installed releases match the release pinned in CI
-  * [ ] Post the exact command and complete output in the spell PR before deployment
 * Deploy spell on mainnet
   * [ ] `make deploy`
   * Ensure `src/test/config.sol` is edited correctly
@@ -330,6 +329,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
 * [ ] Post a comment inside the PR containing:
+  * The exact pre-deployment Foundry verification command
+  * The complete verifier output
+  * Confirmation that the verifier exited `0`
+  * Confirmation that the desired and installed releases match the release pinned in CI
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")
@@ -337,7 +340,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 ## Handover and Merge Stage
 
-* [ ] Wait for at least two "good to handover" comments (containing local tests) from the official reviewers
+* [ ] Wait for explicit "good to handover" approval replies from both official reviewers on the deployment-information comment
 * Communicate deployed address to governance
   * [ ] Write a message with Deployed Address in [`new-spells` discord channel](https://discord.com/channels/893112320329396265/897483518316265553)
   * [ ] Tag Responsible Governance Facilitator in the message with the address

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -55,13 +55,15 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       _Insert the complete selector output here_
       ```
     * [ ] Treat the selected release as the release under review
-    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release under review
-    * [ ] IF an applicable advisory links an official Foundry incident notice, review that notice for unresolved issues affecting the release
-      ```text
-      Security review: Unaffected / Affected / Applicability unclear
-      Security advisories: _Insert URLs and outcome_
-      Linked incident notices: None / _Insert URLs and outcome_
-      ```
+    * Review the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
+      * [ ] Read each potentially applicable advisory and determine whether its affected version range includes the release
+      * [ ] Review every official upstream advisory or incident notice linked from an applicable advisory for unresolved issues affecting the release
+      * [ ] Record the security review evidence
+        ```text
+        Security review: Unaffected / Affected / Applicability unclear
+        Security advisories: None affecting the release / _Insert URLs and outcome_
+        Linked official sources: None / _Insert URLs and outcome_
+        ```
     * [ ] Copy the workflow-level Foundry settings from the local `.github/workflows/tests.yaml` into the block below
       ```text
       FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
@@ -79,9 +81,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         * [ ] Select an exact alternative supported by an official upstream reference
         * [ ] Treat the alternative as the release under review
         * [ ] Repeat the security and applicable compatibility checks above
-      * [ ] Post the alternative version and upstream reference in the spell PR
-      * [ ] IF the alternative is less than 14 days old, include an explicit cooling-period waiver request in the same comment
-      * [ ] Obtain explicit approval from both spell reviewers for the alternative and, IF applicable, its cooling-period waiver in follow-up comments
+      * [ ] Post a spell PR comment containing the exact alternative release to install and its upstream reference
+        * [ ] IF the alternative is less than 14 days old, include an explicit cooling-period waiver request in the same comment
+      * [ ] Obtain explicit approval from both spell reviewers in replies to that comment
     * [ ] Record the passing selected release or passing explicitly approved alternative as the required release
       ```text
       Required release: vMAJOR.MINOR.PATCH
@@ -108,7 +110,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * [ ] Stop Foundry setup
       * [ ] Record the failed command and complete output in the spell PR
       * [ ] Diagnose and resolve the failure
-      * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`; the failure does not authorize another automatic installation
+      * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`
       * [ ] Rerun the exact failed command
         ```text
         _Insert the complete command output here_
@@ -315,9 +317,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
 * [ ] Post a comment inside the PR containing:
-  * The exact pre-deployment Foundry verification command
+  * The exact Foundry verification command run before deployment, with its release and age-waiver arguments matching CI
   * The complete verifier output
   * Confirmation that the verifier exited `0`
+  * Confirmation that the desired and installed releases match the release pinned in CI
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -52,7 +52,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
     FOUNDRY_IGNORE_AGE: 0 / 1
     ```
-  * Treat the selected release as the release under review
+  * [ ] Treat the selected release as the release under review
   * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the release under review
     ```text
     Security review: Unaffected / Affected / Applicability unclear

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -37,14 +37,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 * Verify Foundry tooling
   * [ ] Checkout `spells-mainnet` from a trusted, up-to-date source
-  * [ ] Run `make verify-foundry`
+  * [ ] Run `make select-foundry`
     ```text
-    _Insert the complete verifier output here_
+    _Insert the complete selector output here_
     ```
-  * IF the verifier fails with `Required action: install` and reports:
+  * IF the selector succeeds and reports:
     * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-    * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-    * Review official security sources for the release identified by the verifier
+    * Review official security sources for the release identified by the selector
       * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
         ```text
         Checked at (UTC):
@@ -62,17 +61,25 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         ```
       * [ ] IF applicability is unresolved or unclear, treat the release as affected
     * IF the security review finds no unresolved issue affecting the desired release
-      * [ ] Run the exact `Installation command` printed by the verifier
+      * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`
         ```text
-        _Insert the complete installer output here_
+        _Insert the complete verifier output here_
         ```
-      * IF the installer succeeds
-        * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-        * [ ] Run `make verify-foundry`
+      * [ ] IF the verifier succeeds, confirm that it exits `0`
+      * OTHERWISE IF the verifier fails with `Required action: install` and reports:
+        * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+        * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+        * [ ] Run the exact `Installation command` printed by the verifier
           ```text
-          _Insert the complete verifier output here_
+          _Insert the complete installer output here_
           ```
-        * [ ] Confirm that the verifier exits `0`
+        * IF the installer succeeds
+          * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+          * [ ] Rerun `make verify-foundry release=vMAJOR.MINOR.PATCH`
+            ```text
+            _Insert the complete verifier output here_
+            ```
+          * [ ] Confirm that the verifier exits `0`
     * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the desired release
       * [ ] Notify the spell team
       * [ ] Identify an exact mitigation release
@@ -127,7 +134,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
             * [ ] Confirm that the verifier exits `0`
       * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the mitigation release
         * [ ] Stop the workflow
-  * IF either `make verify-foundry` or `make install-foundry` exits nonzero without printing all of:
+  * IF `make select-foundry` exits nonzero or does not report `Desired Foundry release: vMAJOR.MINOR.PATCH`
+    * [ ] Stop the workflow
+    * [ ] Diagnose the failure
+    * [ ] Resolve the failure
+  * OTHERWISE IF either `make verify-foundry` or `make install-foundry` exits nonzero without printing all of:
     * `Required action: install`
     * `Desired Foundry release: vMAJOR.MINOR.PATCH`
     * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when the cooling period is waived

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -47,32 +47,37 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete selector output here_
     ```
-  * [ ] Record the workflow-level Foundry settings from the local `.github/workflows/tests.yaml` ([upstream file](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml))
+  * [ ] Record the workflow-level Foundry settings from the local [`.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
     ```text
     FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
     FOUNDRY_IGNORE_AGE: 0 / 1
     ```
-  * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the selector release
+  * Treat the selected release as the release under review
+  * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the release under review
     ```text
     Security review: Unaffected / Affected / Applicability unclear
     Sources and rationale: None affecting the release / _Insert URLs and outcome_
     ```
-  * [ ] IF the selector release differs from `FOUNDRY_RELEASE`, read its complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
+  * [ ] IF adopting the release under review changes `FOUNDRY_RELEASE`, read its complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
     ```text
     Release notes: _Insert exact release URL_
     Compatibility: Compatible / Incompatible — _Insert rationale_
     ```
-  * IF the selector release is affected, its applicability is unclear, or it is incompatible
+  * IF the release under review is affected, its applicability is unclear, or it is incompatible
     * [ ] Stop Foundry setup and notify the spell team
-    * [ ] Select an exact alternative supported by an official upstream reference
-    * [ ] Repeat the advisory and applicable release-note checks for the alternative
+    * Repeat until the release under review is unaffected and, when compatibility is checked, compatible
+      * [ ] Select an exact alternative supported by an official upstream reference
+      * [ ] Treat the alternative as the release under review
+      * [ ] Repeat the security and applicable compatibility checks above
     * [ ] Post the alternative version and upstream reference in the spell PR
     * [ ] Obtain explicit approval from both spell reviewers
-  * [ ] Record the selector release as the required release, or the explicitly approved alternative
+  * [ ] Record the passing selected release, or the passing explicitly approved alternative, as the required release
     ```text
     Required release: vMAJOR.MINOR.PATCH
     ```
-  * [ ] IF the required release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
+  * IF the required release is less than 14 days old
+    * [ ] Post a spell PR comment requesting an explicit cooling-period waiver
+    * [ ] Obtain explicit approval from both spell reviewers in follow-up comments
   * [ ] IF either CI setting differs, set `FOUNDRY_RELEASE` to the required release and `FOUNDRY_IGNORE_AGE` to `"1"` when the cooling period is waived or `"0"` otherwise
   * [ ] IF the Foundry workflow changes, confirm that `make install-foundry` and `make verify-foundry` use both CI settings
   * [ ] IF the required release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
@@ -91,7 +96,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```
   * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
   * IF any Foundry setup command exits nonzero other than the expected install response above
-    * Stop Foundry setup
+    * [ ] Stop Foundry setup
     * [ ] Record the failed command and complete output in the spell PR
     * [ ] Diagnose and resolve the failure
     * [ ] Rerun the exact failed command

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -66,7 +66,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       Release notes: _Insert exact release URL_
       Compatibility: Compatible / Incompatible — _Insert rationale_
       ```
-    * IF the release under review is affected, its applicability is unclear, or it is incompatible
+    * IF the release under review does not pass the security review or applicable compatibility check
       * [ ] Stop Foundry setup and notify the spell team
       * Repeat until the release under review is unaffected and, when compatibility is checked, compatible
         * [ ] Select an exact alternative supported by an official upstream reference

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -66,15 +66,17 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       _Insert the complete selector output here_
       ```
     * [ ] Treat the selected release as the release under review
-    * Review every published Foundry [security advisory](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
-      * [ ] For each advisory, compare its affected version range with the release under review
-      * [ ] For each advisory that affects the release or whose applicability is unclear, review every linked official upstream advisory or incident notice for unresolved issues affecting the release
-      * [ ] Record one evidence entry per advisory; IF no advisories are published, record `None published`
-        ```text
-        Foundry advisory: None published / _Insert URL_
-        Affects release under review: N/A / Yes / No / Unclear — _Insert rationale_
-        Linked official sources: N/A / None / _Insert URLs and outcome_
-        ```
+    * [ ] Review every published Foundry [security advisory](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
+      * [ ] IF no advisories are published, strike through this item and remove the evidence block below
+      * OTHERWISE, for each advisory
+        * [ ] Compare its affected version range with the release under review
+        * [ ] IF the release is affected or applicability is unclear, review every linked official upstream source
+        * [ ] Record the evidence below
+          ```text
+          Foundry advisory: _Insert URL_
+          Affects release under review: Yes / No / Unclear — _Insert rationale_
+          Linked official sources: None / _Insert URLs and outcome_
+          ```
     * [ ] Copy the workflow-level Foundry settings from the local `.github/workflows/tests.yaml` into the block below
       ```text
       FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
@@ -297,12 +299,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
     FOUNDRY_IGNORE_AGE: 0 / 1
     ```
-  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=0/1` with those exact values, matching the `Verify Foundry` CI step
+  * [ ] Confirm that the `Verify Foundry` CI step passes `${FOUNDRY_RELEASE}` and `${FOUNDRY_IGNORE_AGE}` to `make verify-foundry`
+  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=0/1` locally with the exact workflow-level values recorded above
     ```text
     _Insert the complete verifier output here_
     ```
-  * [ ] Confirm that the verifier exits `0`
-  * [ ] Confirm that the desired and installed releases match the release pinned in CI
+  * [ ] Confirm that the verifier exits `0` and reports the recorded `FOUNDRY_RELEASE` as both the desired and installed release
 * Deploy spell on mainnet
   * [ ] `make deploy`
   * Ensure `src/test/config.sol` is edited correctly

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -48,7 +48,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```text
       _Insert the complete selector output here_
       ```
-    * [ ] Record the workflow-level Foundry settings from the local [`.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
+    * [ ] Copy the workflow-level Foundry settings from the local `.github/workflows/tests.yaml` into the block below
       ```text
       FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
       FOUNDRY_IGNORE_AGE: 0 / 1
@@ -72,7 +72,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         * [ ] Repeat the security and applicable compatibility checks above
       * [ ] Post the alternative version and upstream reference in the spell PR
       * [ ] Obtain explicit approval from both spell reviewers
-    * [ ] Record the passing selected release, or the passing explicitly approved alternative, as the required release
+    * [ ] Record the passing selected release or passing explicitly approved alternative as the required release
       ```text
       Required release: vMAJOR.MINOR.PATCH
       ```
@@ -83,7 +83,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * IF the required release differs from the recorded `FOUNDRY_RELEASE`
       * [ ] Set `FOUNDRY_RELEASE` to the required release
       * [ ] Set `FOUNDRY_IGNORE_AGE` to `"1"` only for an approved cooling-period waiver or `"0"` otherwise
-      * [ ] Confirm that `make install-foundry` and `make verify-foundry` use both CI settings
+      * [ ] Confirm that the `Install Foundry` step in `.github/workflows/tests.yaml` runs `make install-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
+      * [ ] Confirm that the `Verify Foundry` step in `.github/workflows/tests.yaml` runs `make verify-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
   * Phase 3 — Mandatory developer installation and verification
     * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
       ```text
@@ -95,8 +96,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       _Insert the complete verifier output here_
       ```
     * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
-  * Phase 4 — Conditional failure handling
-    * IF any Foundry setup command in Phases 1–3 exits nonzero, apply this recovery branch immediately
+  * Failure handling — applies throughout Phases 1–3
+    * IF any Foundry setup command above exits nonzero, apply this recovery branch immediately
       * [ ] Stop Foundry setup
       * [ ] Record the failed command and complete output in the spell PR
       * [ ] Diagnose and resolve the failure

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -47,87 +47,53 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete selector output here_
     ```
-  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the selector release
   * [ ] Record the workflow-level Foundry settings from the local `.github/workflows/tests.yaml` ([upstream file](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml))
     ```text
     FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
     FOUNDRY_IGNORE_AGE: 0 / 1
     ```
-  * Review the selector release and each alternative candidate release selected below
-    * Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories)
-      * [ ] Confirm that no affected version range includes the release
-        ```text
-        Security advisory URL: None / _Insert exact URL_
-        Release affected: Yes / No
-        Reason: _Insert why or why not the release is affected_
-        ```
-      * [ ] IF a security advisory links to a supplemental official advisory or incident notice, read it and determine its applicability and remediation
-        ```text
-        Linked official notices: None / _Insert URLs and applicability or remediation outcomes_
-        ```
-    * IF the candidate differs from `FOUNDRY_RELEASE`, review it as a CI release update
-      * Confirm from the release's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
-        * [ ] The release is not a draft
-        * [ ] The release is not a prerelease
-        * [ ] The release is marked immutable
-        ```text
-        Release metadata URL: _Insert exact release URL_
-        Draft: Yes / No
-        Prerelease: Yes / No
-        Immutable: Yes / No
-        ```
-      * Read the release's complete Foundry [release notes](https://github.com/foundry-rs/foundry/releases)
-        * [ ] Identify every breaking change
-          ```text
-          Release notes: _Insert exact release URL_
-          Breaking changes: None / _Insert breaking changes_
-          ```
-        * [ ] IF breaking changes exist, determine whether they are compatible with spell building, testing, and deployment
-          ```text
-          Compatibility outcome: Compatible / Incompatible
-          ```
-    * [ ] Record whether the release is acceptable
-      ```text
-      Candidate release: vMAJOR.MINOR.PATCH
-      Outcome: Acceptable / Affected / Applicability unclear / Incompatible
-      ```
-  * IF the candidate is not acceptable
-    * [ ] Notify the spell team
-    * [ ] Identify an exact alternative release, either older or newer
-    * [ ] Locate an official upstream reference showing that the alternative is unaffected or addresses the issue
-    * [ ] Repeat the exact release review above for the alternative
-  * IF an alternative release is selected
-    * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
-    * [ ] Both spell reviewers reply to that comment with explicit approval
-  * [ ] Record the selector release as the required release, or the explicitly approved alternative when one was selected
-  * [ ] Confirm that the required release has an `Acceptable` review outcome
+  * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the selector release
+    ```text
+    Security review: Unaffected / Affected / Applicability unclear
+    Sources and rationale: None affecting the release / _Insert URLs and outcome_
+    ```
+  * [ ] IF the selector release differs from `FOUNDRY_RELEASE`, read its complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
+    ```text
+    Release notes: _Insert exact release URL_
+    Compatibility: Compatible / Incompatible — _Insert rationale_
+    ```
+  * IF the selector release is affected, its applicability is unclear, or it is incompatible
+    * [ ] Stop Foundry setup and notify the spell team
+    * [ ] Select an exact alternative supported by an official upstream reference
+    * [ ] Repeat the advisory and applicable release-note checks for the alternative
+    * [ ] Post the alternative version and upstream reference in the spell PR
+    * [ ] Obtain explicit approval from both spell reviewers
+  * [ ] Record the selector release as the required release, or the explicitly approved alternative
+    ```text
+    Required release: vMAJOR.MINOR.PATCH
+    ```
   * [ ] IF the required release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] IF `FOUNDRY_RELEASE` does not match the required release, update it in the local `.github/workflows/tests.yaml`
-  * [ ] IF `FOUNDRY_IGNORE_AGE` is not `"1"` when the cooling period is waived or `"0"` otherwise, update it in the local `.github/workflows/tests.yaml`
-  * [ ] Confirm that `make install-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
-  * [ ] Confirm that `make verify-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
+  * [ ] IF either CI setting differs, set `FOUNDRY_RELEASE` to the required release and `FOUNDRY_IGNORE_AGE` to `"1"` when the cooling period is waived or `"0"` otherwise
+  * [ ] IF the Foundry workflow changes, confirm that `make install-foundry` and `make verify-foundry` use both CI settings
   * [ ] IF the required release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
     ```text
     _Insert the complete verifier output here_
     ```
-  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the required release
-  * [ ] OTHERWISE IF the exact-release verifier fails with `Required action: install`, confirm that it reports:
-    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the required release
-    * [ ] `Installation command:` matching the required release and including `ignore-age=1` when the cooling period is waived
+  * IF the verifier exits nonzero with `Required action: install`, the required release, and a matching `Installation command`
     * [ ] Run the exact `Installation command` printed by the verifier
       ```text
       _Insert the complete installer output here_
       ```
     * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-    * [ ] IF the installer exits `0`, rerun the same exact-release verifier
+    * [ ] Rerun the same exact-release verifier
       ```text
       _Insert the complete verifier output here_
       ```
-      * [ ] Confirm that the verifier exits `0`
-  * [ ] IF `make select-foundry` or `make install-foundry` exits nonzero, or `make verify-foundry` exits nonzero without the expected `Required action: install`, desired release, and installation command, record the failed command and complete output in the spell PR
-    * [ ] Stop Foundry setup
-    * [ ] Diagnose the failure
-    * [ ] Resolve the failure
+  * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
+  * IF any Foundry setup command exits nonzero other than the expected install response above
+    * Stop Foundry setup
+    * [ ] Record the failed command and complete output in the spell PR
+    * [ ] Diagnose and resolve the failure
     * [ ] Rerun the exact failed command
       ```text
       _Insert the complete command output here_

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -48,15 +48,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     CI Foundry release: vMAJOR.MINOR.PATCH
     CI age waiver: None / ignore-age=1
     ```
-  * [ ] Run `make verify-foundry`
+  * [ ] Run `make select-foundry`
     ```text
     _Insert the complete selector output here_
     ```
-  * IF the verifier exits nonzero, confirm that it reports:
-    * [ ] `Required action: install`
-    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH`
-    * [ ] `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-  * [ ] Record the verifier's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the first candidate release
+  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the first candidate release
   * Review each exact candidate release
     * Confirm from the candidate's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
       * [ ] The release is not a draft
@@ -126,7 +122,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         _Insert the complete verifier output here_
         ```
       * [ ] Confirm that the verifier exits `0`
-  * IF either unexpected Foundry setup failure occurs:
+  * IF any unexpected Foundry setup failure occurs:
+    * A `make select-foundry` invocation exits nonzero or does not report `Desired Foundry release: vMAJOR.MINOR.PATCH`
     * A `make verify-foundry` invocation exits nonzero without:
       * `Required action: install`
       * `Desired Foundry release: vMAJOR.MINOR.PATCH`

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -318,7 +318,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 ## Handover and Merge Stage
 
-* [ ] Wait for explicit "good to handover" approval replies from both official reviewers on the deployment-information comment
+* [ ] Wait for explicit "good to handover" comments from both official reviewers confirming the deployment information
 * Communicate deployed address to governance
   * [ ] Write a message with Deployed Address in [`new-spells` discord channel](https://discord.com/channels/893112320329396265/897483518316265553)
   * [ ] Tag Responsible Governance Facilitator in the message with the address

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -89,12 +89,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * [ ] Confirm that the `Install Foundry` step in `.github/workflows/tests.yaml` runs `make install-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
       * [ ] Confirm that the `Verify Foundry` step in `.github/workflows/tests.yaml` runs `make verify-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
   * Phase 3 — Mandatory developer installation and verification
-    * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
+    * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; IF the required release is less than 14 days old and its cooling-period waiver was approved, include `ignore-age=1`
       ```text
       _Insert the complete installer output here_
       ```
     * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-    * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
+    * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`; IF the required release is less than 14 days old and its cooling-period waiver was approved, include `ignore-age=1`
       ```text
       _Insert the complete verifier output here_
       ```

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -66,9 +66,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       _Insert the complete selector output here_
       ```
     * [ ] Treat the selected release as the release under review
-    * [ ] Review every published Foundry [security advisory](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
-      * [ ] IF no advisories are published, strike through this item and remove the evidence block below
-      * OTHERWISE, for each advisory
+    * IF there are any published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
+      * For each advisory
         * [ ] Compare its affected version range with the release under review
         * [ ] IF the release is affected or applicability is unclear, review every linked official upstream source
         * [ ] Record the evidence below

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -49,20 +49,31 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell
 * Verify and install the Foundry toolkit
+  * Failure handling — applies throughout Phases 1–3
+    * IF any Foundry setup command below exits nonzero, apply this recovery branch immediately
+      * [ ] Stop Foundry setup
+      * [ ] Record the failed command and complete output in the spell PR
+      * [ ] Diagnose and resolve the failure
+      * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`
+      * [ ] Rerun the exact failed command
+        ```text
+        _Insert the complete command output here_
+        ```
+      * [ ] IF the failure cannot be resolved, notify the spell team
   * Phase 1 — Mandatory release acceptance
     * [ ] Run `make select-foundry`
       ```text
       _Insert the complete selector output here_
       ```
     * [ ] Treat the selected release as the release under review
-    * Review the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
-      * [ ] Read each potentially applicable advisory and determine whether its affected version range includes the release
-      * [ ] Review every official upstream advisory or incident notice linked from an applicable advisory for unresolved issues affecting the release
-      * [ ] Record the security review evidence
+    * Review every published Foundry [security advisory](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
+      * [ ] For each advisory, compare its affected version range with the release under review
+      * [ ] For each advisory that affects the release or whose applicability is unclear, review every linked official upstream advisory or incident notice for unresolved issues affecting the release
+      * [ ] Record one evidence entry per advisory; IF no advisories are published, record `None published`
         ```text
-        Security review: Unaffected / Affected / Applicability unclear
-        Security advisories: None affecting the release / _Insert URLs and outcome_
-        Linked official sources: None / _Insert URLs and outcome_
+        Foundry advisory: None published / _Insert URL_
+        Affects release under review: N/A / Yes / No / Unclear — _Insert rationale_
+        Linked official sources: N/A / None / _Insert URLs and outcome_
         ```
     * [ ] Copy the workflow-level Foundry settings from the local `.github/workflows/tests.yaml` into the block below
       ```text
@@ -83,7 +94,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         * [ ] Repeat the security and applicable compatibility checks above
       * [ ] Post a spell PR comment containing the exact alternative release to install and its upstream reference
         * [ ] IF the alternative is less than 14 days old, include an explicit cooling-period waiver request in the same comment
-      * [ ] Obtain explicit approval from both spell reviewers in replies to that comment
+      * [ ] Obtain explicit approval from both spell reviewers in replies; each reply must name the exact alternative release and state whether the cooling-period waiver is approved or not required
     * [ ] Record the passing selected release or passing explicitly approved alternative as the required release
       ```text
       Required release: vMAJOR.MINOR.PATCH
@@ -105,17 +116,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       _Insert the complete verifier output here_
       ```
     * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
-  * Failure handling — applies throughout Phases 1–3
-    * IF any Foundry setup command above exits nonzero, apply this recovery branch immediately
-      * [ ] Stop Foundry setup
-      * [ ] Record the failed command and complete output in the spell PR
-      * [ ] Diagnose and resolve the failure
-      * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`
-      * [ ] Rerun the exact failed command
-        ```text
-        _Insert the complete command output here_
-        ```
-      * [ ] IF the failure cannot be resolved, notify the spell team
 * Cleanup previous spell's actions
   * [ ] Check previous pull requests for the cleanup patterns
   * [ ] Delete unused dependencies in the `src/dependencies` folder IF applicable
@@ -292,7 +292,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] `cast wallet address --keystore $ETH_KEYSTORE` shows the deployer address
     * [ ] `cast chain-id` shows `1` for Mainnet
 * Verify the CI-pinned Foundry release
-  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when `FOUNDRY_IGNORE_AGE` is `"1"` in CI
+  * [ ] Copy the current workflow-level Foundry settings from the local `.github/workflows/tests.yaml`
+    ```text
+    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+    FOUNDRY_IGNORE_AGE: 0 / 1
+    ```
+  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=0/1` with those exact values, matching the `Verify Foundry` CI step
     ```text
     _Insert the complete verifier output here_
     ```

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -68,7 +68,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```
     * IF the release under review does not pass the security review or applicable compatibility check
       * [ ] Stop Foundry setup and notify the spell team
-      * Repeat until the release under review is unaffected and, when compatibility is checked, compatible
+      * Repeat until the release under review passes the security review and any required compatibility check
         * [ ] Select an exact alternative supported by an official upstream reference
         * [ ] Treat the alternative as the release under review
         * [ ] Repeat the security and applicable compatibility checks above

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -43,17 +43,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell
 * Verify and Install Foundry toolkit
-  * [ ] Record the workflow-level Foundry settings from [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
-    ```text
-    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
-    FOUNDRY_IGNORE_AGE: 0 / 1
-    ```
   * [ ] Run `make select-foundry`
     ```text
     _Insert the complete selector output here_
     ```
-  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the desired release
-  * Review the desired release and each alternative candidate release selected below
+  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the selector release
+  * Review the selector release and each alternative candidate release selected below
     * Confirm from the release's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
       * [ ] The release is not a draft
       * [ ] The release is not a prerelease
@@ -98,21 +93,26 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * IF an alternative release is selected
     * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
     * [ ] Both spell reviewers reply to that comment with explicit approval
-  * [ ] Confirm that the selected release has an `Acceptable` review outcome
-  * [ ] Compare the selected release with the current `FOUNDRY_RELEASE`
-  * [ ] IF the selected release differs from the CI release, update `FOUNDRY_RELEASE` in [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
-  * [ ] IF the selected release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] IF the cooling-period waiver applies, set `FOUNDRY_IGNORE_AGE` to `"1"` in [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml); OTHERWISE set it to `"0"`
+  * [ ] Record the selector release as the required release, or the explicitly approved alternative when one was selected
+  * [ ] Confirm that the required release has an `Acceptable` review outcome
+  * [ ] IF the required release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
+  * [ ] Record the workflow-level Foundry settings from the local `.github/workflows/tests.yaml` ([upstream file](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml))
+    ```text
+    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+    FOUNDRY_IGNORE_AGE: 0 / 1
+    ```
+  * [ ] IF `FOUNDRY_RELEASE` does not match the required release, update it in the local `.github/workflows/tests.yaml`
+  * [ ] IF `FOUNDRY_IGNORE_AGE` is not `"1"` when the cooling period is waived or `"0"` otherwise, update it in the local `.github/workflows/tests.yaml`
   * [ ] Confirm that `make install-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
   * [ ] Confirm that `make verify-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
-  * [ ] IF the selected release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
+  * [ ] IF the required release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
     ```text
     _Insert the complete verifier output here_
     ```
-  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the selected release
+  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the required release
   * [ ] OTHERWISE IF the exact-release verifier fails with `Required action: install`, confirm that it reports:
-    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the selected release
-    * [ ] `Installation command:` matching the selected release and including `ignore-age=1` when the cooling period is waived
+    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the required release
+    * [ ] `Installation command:` matching the required release and including `ignore-age=1` when the cooling period is waived
     * [ ] Run the exact `Installation command` printed by the verifier
       ```text
       _Insert the complete installer output here_

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -67,7 +67,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       Compatibility: Compatible / Incompatible — _Insert rationale_
       ```
     * IF the release under review does not pass the security review or applicable compatibility check
-      * [ ] Stop Foundry setup and notify the spell team
+      * [ ] Stop Foundry setup
+      * [ ] Notify the spell team that the release under review failed the security review or applicable compatibility check
       * Repeat until the release under review passes the security review and any required compatibility check
         * [ ] Select an exact alternative supported by an official upstream reference
         * [ ] Treat the alternative as the release under review

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -85,7 +85,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * Phase 2 — Conditional CI synchronization
     * IF the required release differs from the recorded `FOUNDRY_RELEASE`
       * [ ] Set `FOUNDRY_RELEASE` to the required release
-      * [ ] Set `FOUNDRY_IGNORE_AGE` to `"1"` only for an approved cooling-period waiver or `"0"` otherwise
+      * [ ] IF a cooling-period waiver was approved, set `FOUNDRY_IGNORE_AGE` to `"1"`; OTHERWISE set it to `"0"`
       * [ ] Confirm that the `Install Foundry` step in `.github/workflows/tests.yaml` runs `make install-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
       * [ ] Confirm that the `Verify Foundry` step in `.github/workflows/tests.yaml` runs `make verify-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
   * Phase 3 — Mandatory developer installation and verification

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -100,12 +100,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```text
       Required release: vMAJOR.MINOR.PATCH
       ```
-  * Phase 2 — Conditional CI synchronization
-    * IF the required release differs from the recorded `FOUNDRY_RELEASE`
-      * [ ] Set `FOUNDRY_RELEASE` to the required release
-      * [ ] IF a cooling-period waiver was approved, set `FOUNDRY_IGNORE_AGE` to `"1"`; OTHERWISE set it to `"0"`
-      * [ ] Confirm that the `Install Foundry` step in `.github/workflows/tests.yaml` runs `make install-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
-      * [ ] Confirm that the `Verify Foundry` step in `.github/workflows/tests.yaml` runs `make verify-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
+  * Phase 2 — CI synchronization
+    * [ ] Ensure `FOUNDRY_RELEASE` matches the required release, updating it if necessary
+    * [ ] IF a cooling-period waiver was approved, ensure `FOUNDRY_IGNORE_AGE` is `"1"`, updating it if necessary
+    * [ ] OTHERWISE, ensure `FOUNDRY_IGNORE_AGE` is `"0"`, updating it if necessary
+    * [ ] Confirm that the `Install Foundry` step in `.github/workflows/tests.yaml` runs `make install-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
+    * [ ] Confirm that the `Verify Foundry` step in `.github/workflows/tests.yaml` runs `make verify-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
   * Phase 3 — Mandatory developer installation and verification
     * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; IF the required release is less than 14 days old and its cooling-period waiver was approved, include `ignore-age=1`
       ```text

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -311,7 +311,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * The exact pre-deployment Foundry verification command
   * The complete verifier output
   * Confirmation that the verifier exited `0`
-  * Confirmation that the desired and installed releases match the release pinned in CI
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -43,10 +43,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell
 * Verify and Install Foundry toolkit
-  * [ ] Record the exact Foundry release and optional age waiver used by both `make install-foundry` and `make verify-foundry` in `.github/workflows/tests.yaml`
+  * [ ] Record the workflow-level Foundry settings from `.github/workflows/tests.yaml`
     ```text
-    CI Foundry release: vMAJOR.MINOR.PATCH
-    CI age waiver: None / ignore-age=1
+    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+    FOUNDRY_IGNORE_AGE: 0 / 1
     ```
   * [ ] Run `make select-foundry`
     ```text
@@ -92,13 +92,14 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
     * [ ] Obtain explicit spell-team approval in a reply to that comment or another spell PR comment
   * [ ] Confirm that the selected candidate has an `Acceptable` review outcome
-  * [ ] Compare the selected candidate with the current CI Foundry release
-  * [ ] IF the selected candidate differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
+  * [ ] Compare the selected candidate with the current `FOUNDRY_RELEASE`
+  * [ ] IF the selected candidate differs from the CI release, update `FOUNDRY_RELEASE` in `.github/workflows/tests.yaml`
   * [ ] IF the selected candidate is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in `.github/workflows/tests.yaml`
-  * [ ] IF no cooling-period waiver applies, remove `ignore-age=1` from both Foundry commands in `.github/workflows/tests.yaml`
-  * [ ] Confirm that both CI commands use the same release and age-waiver arguments
-  * The CI release remains pinned until a later approved release replaces it
+  * [ ] IF the cooling-period waiver applies, set `FOUNDRY_IGNORE_AGE` to `"1"` in `.github/workflows/tests.yaml`
+  * [ ] IF no cooling-period waiver applies, set `FOUNDRY_IGNORE_AGE` to `"0"` in `.github/workflows/tests.yaml`
+  * [ ] Confirm that `make install-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
+  * [ ] Confirm that `make verify-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
+  * The CI release and age-waiver setting remain pinned until a later approved change replaces them
   * [ ] IF the selected candidate is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
     ```text
     _Insert the complete verifier output here_
@@ -311,7 +312,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] `cast wallet address --keystore $ETH_KEYSTORE` shows the deployer address
     * [ ] `cast chain-id` shows `1` for Mainnet
 * Verify the CI-pinned Foundry release
-  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when it is present in CI
+  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when `FOUNDRY_IGNORE_AGE` is `"1"` in CI
     ```text
     _Insert the complete verifier output here_
     ```

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -48,17 +48,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete selector output here_
     ```
   * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the selector release
+  * [ ] Record the workflow-level Foundry settings from the local `.github/workflows/tests.yaml` ([upstream file](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml))
+    ```text
+    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+    FOUNDRY_IGNORE_AGE: 0 / 1
+    ```
   * Review the selector release and each alternative candidate release selected below
-    * Confirm from the release's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
-      * [ ] The release is not a draft
-      * [ ] The release is not a prerelease
-      * [ ] The release is marked immutable
-      ```text
-      Release metadata URL: _Insert exact release URL_
-      Draft: Yes / No
-      Prerelease: Yes / No
-      Immutable: Yes / No
-      ```
     * Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories)
       * [ ] Confirm that no affected version range includes the release
         ```text
@@ -70,16 +65,27 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         ```text
         Linked official notices: None / _Insert URLs and applicability or remediation outcomes_
         ```
-    * Read the release's complete Foundry [release notes](https://github.com/foundry-rs/foundry/releases)
-      * [ ] Identify every breaking change
+    * IF the candidate differs from `FOUNDRY_RELEASE`, review it as a CI release update
+      * Confirm from the release's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
+        * [ ] The release is not a draft
+        * [ ] The release is not a prerelease
+        * [ ] The release is marked immutable
         ```text
-        Release notes: _Insert exact release URL_
-        Breaking changes: None / _Insert breaking changes_
+        Release metadata URL: _Insert exact release URL_
+        Draft: Yes / No
+        Prerelease: Yes / No
+        Immutable: Yes / No
         ```
-      * [ ] IF breaking changes exist, determine whether they are compatible with spell building, testing, and deployment
-        ```text
-        Compatibility outcome: Compatible / Incompatible
-        ```
+      * Read the release's complete Foundry [release notes](https://github.com/foundry-rs/foundry/releases)
+        * [ ] Identify every breaking change
+          ```text
+          Release notes: _Insert exact release URL_
+          Breaking changes: None / _Insert breaking changes_
+          ```
+        * [ ] IF breaking changes exist, determine whether they are compatible with spell building, testing, and deployment
+          ```text
+          Compatibility outcome: Compatible / Incompatible
+          ```
     * [ ] Record whether the release is acceptable
       ```text
       Candidate release: vMAJOR.MINOR.PATCH
@@ -96,11 +102,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Record the selector release as the required release, or the explicitly approved alternative when one was selected
   * [ ] Confirm that the required release has an `Acceptable` review outcome
   * [ ] IF the required release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] Record the workflow-level Foundry settings from the local `.github/workflows/tests.yaml` ([upstream file](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml))
-    ```text
-    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
-    FOUNDRY_IGNORE_AGE: 0 / 1
-    ```
   * [ ] IF `FOUNDRY_RELEASE` does not match the required release, update it in the local `.github/workflows/tests.yaml`
   * [ ] IF `FOUNDRY_IGNORE_AGE` is not `"1"` when the cooling period is waived or `"0"` otherwise, update it in the local `.github/workflows/tests.yaml`
   * [ ] Confirm that `make install-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -52,84 +52,77 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete selector output here_
     ```
-  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the first candidate release
-  * Review each exact candidate release
-    * Confirm from the candidate's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
+  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the desired release
+  * Review the desired release and each alternative candidate release selected below
+    * Confirm from the release's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
       * [ ] The release is not a draft
       * [ ] The release is not a prerelease
       * [ ] The release is marked immutable
       ```text
-      Release metadata: _Insert exact release URL and outcome_
+      Release metadata URL: _Insert exact release URL_
+      Draft: Yes / No
+      Prerelease: Yes / No
+      Immutable: Yes / No
       ```
-    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) to confirm that no affected version range includes the candidate
-      ```text
-      Security advisories: _Insert URL and outcome_
-      ```
-    * [ ] Read the candidate's complete [release notes](https://github.com/foundry-rs/foundry/releases) and identify every breaking change
-      ```text
-      Release notes: _Insert exact release URL_
-      Breaking changes: None / _Insert breaking changes_
-      ```
-    * [ ] Determine whether the breaking changes are compatible with spell building, testing, and deployment
-      ```text
-      Compatibility outcome: Compatible / Incompatible
-      ```
-    * [ ] IF a security advisory or the release notes link to a supplemental official advisory or incident notice, read it and determine its applicability and remediation
-      ```text
-      Linked official notices: None / _Insert URLs and applicability or remediation outcomes_
-      ```
-    * [ ] Record whether the candidate is acceptable
+    * Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories)
+      * [ ] Confirm that no affected version range includes the release
+        ```text
+        Security advisory URL: None / _Insert exact URL_
+        Release affected: Yes / No
+        Reason: _Insert why or why not the release is affected_
+        ```
+      * [ ] IF a security advisory links to a supplemental official advisory or incident notice, read it and determine its applicability and remediation
+        ```text
+        Linked official notices: None / _Insert URLs and applicability or remediation outcomes_
+        ```
+    * Read the release's complete Foundry [release notes](https://github.com/foundry-rs/foundry/releases)
+      * [ ] Identify every breaking change
+        ```text
+        Release notes: _Insert exact release URL_
+        Breaking changes: None / _Insert breaking changes_
+        ```
+      * [ ] IF breaking changes exist, determine whether they are compatible with spell building, testing, and deployment
+        ```text
+        Compatibility outcome: Compatible / Incompatible
+        ```
+    * [ ] Record whether the release is acceptable
       ```text
       Candidate release: vMAJOR.MINOR.PATCH
       Outcome: Acceptable / Affected / Applicability unclear / Incompatible
       ```
-  * IF the candidate is affected, its applicability is unclear, or it has an incompatible breaking change
+  * IF the candidate is not acceptable
     * [ ] Notify the spell team
     * [ ] Identify an exact alternative release, either older or newer
     * [ ] Locate an official upstream reference showing that the alternative is unaffected or addresses the issue
-    * [ ] Repeat the exact candidate-release review above for the alternative
+    * [ ] Repeat the exact release review above for the alternative
   * IF an alternative release is selected
     * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
     * [ ] Obtain explicit spell-team approval in a reply to that comment or another spell PR comment
-  * [ ] Confirm that the selected candidate has an `Acceptable` review outcome
-  * [ ] Compare the selected candidate with the current CI Foundry release
-  * [ ] IF the selected candidate differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
-  * [ ] IF the selected candidate is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in `.github/workflows/tests.yaml`
-  * [ ] IF no cooling-period waiver applies, remove `ignore-age=1` from both Foundry commands in `.github/workflows/tests.yaml`
+  * [ ] Confirm that the selected release has an `Acceptable` review outcome
+  * [ ] Compare the selected release with the current CI Foundry release
+  * [ ] IF the selected release differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
+  * [ ] IF the selected release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
+  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in `.github/workflows/tests.yaml`; OTHERWISE remove `ignore-age=1`
   * [ ] Confirm that both CI commands use the same release and age-waiver arguments
-  * The CI release remains pinned until a later approved release replaces it
-  * [ ] IF the selected candidate is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
+  * [ ] IF the selected release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
     ```text
     _Insert the complete verifier output here_
     ```
-  * [ ] OTHERWISE IF the selected candidate is less than 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
-    ```text
-    _Insert the complete verifier output here_
-    ```
-  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the selected candidate
-  * OTHERWISE IF the exact-release verifier fails with `Required action: install` and reports:
-    * `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the selected candidate
-    * `Installation command:` matching the selected candidate and including `ignore-age=1` when the cooling period is waived
+  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the selected release
+  * [ ] OTHERWISE IF the exact-release verifier fails with `Required action: install`, confirm that it reports:
+    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the selected release
+    * [ ] `Installation command:` matching the selected release and including `ignore-age=1` when the cooling period is waived
     * [ ] Run the exact `Installation command` printed by the verifier
       ```text
       _Insert the complete installer output here_
       ```
     * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-    * IF the installer exits `0`
-      * [ ] Rerun the same exact-release verifier
-        ```text
-        _Insert the complete verifier output here_
-        ```
+    * [ ] IF the installer exits `0`, rerun the same exact-release verifier
+      ```text
+      _Insert the complete verifier output here_
+      ```
       * [ ] Confirm that the verifier exits `0`
-  * IF any unexpected Foundry setup failure occurs:
-    * A `make select-foundry` invocation exits nonzero or does not report `Desired Foundry release: vMAJOR.MINOR.PATCH`
-    * A `make verify-foundry` invocation exits nonzero without:
-      * `Required action: install`
-      * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-      * `Installation command:` matching the desired release and including `ignore-age=1` when the cooling period is waived
-    * A `make install-foundry` invocation exits nonzero
-    * [ ] Record the failed command and complete output in the spell PR
+  * [ ] IF `make select-foundry` or `make install-foundry` exits nonzero, or `make verify-foundry` exits nonzero without the expected `Required action: install`, desired release, and installation command, record the failed command and complete output in the spell PR
     * [ ] Stop Foundry setup
     * [ ] Diagnose the failure
     * [ ] Resolve the failure

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -74,14 +74,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         * [ ] Treat the alternative as the release under review
         * [ ] Repeat the security and applicable compatibility checks above
       * [ ] Post the alternative version and upstream reference in the spell PR
-      * [ ] Obtain explicit approval from both spell reviewers in follow-up comments
+      * [ ] IF the alternative is less than 14 days old, include an explicit cooling-period waiver request in the same comment
+      * [ ] Obtain explicit approval from both spell reviewers for the alternative and, IF applicable, its cooling-period waiver in follow-up comments
     * [ ] Record the passing selected release or passing explicitly approved alternative as the required release
       ```text
       Required release: vMAJOR.MINOR.PATCH
       ```
-    * IF the required release is less than 14 days old
-      * [ ] Post a spell PR comment requesting an explicit cooling-period waiver
-      * [ ] Obtain explicit approval from both spell reviewers in follow-up comments
   * Phase 2 — Conditional CI synchronization
     * IF the required release differs from the recorded `FOUNDRY_RELEASE`
       * [ ] Set `FOUNDRY_RELEASE` to the required release

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -42,7 +42,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     git pull --ff-only origin master
     ```
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell
-* Verify and Install Foundry toolkit
+* Verify and install the Foundry toolkit
+  * **Phase 1 — Mandatory release acceptance**
   * [ ] Run `make select-foundry`
     ```text
     _Insert the complete selector output here_
@@ -58,7 +59,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     Security review: Unaffected / Affected / Applicability unclear
     Sources and rationale: None affecting the release / _Insert URLs and outcome_
     ```
-  * [ ] IF adopting the release under review changes `FOUNDRY_RELEASE`, read its complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
+  * [ ] IF adopting the release under review changes the workflow-level `FOUNDRY_RELEASE`, read its complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
     ```text
     Release notes: _Insert exact release URL_
     Compatibility: Compatible / Incompatible — _Insert rationale_
@@ -78,27 +79,28 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * IF the required release is less than 14 days old
     * [ ] Post a spell PR comment requesting an explicit cooling-period waiver
     * [ ] Obtain explicit approval from both spell reviewers in follow-up comments
-  * [ ] IF either CI setting differs, set `FOUNDRY_RELEASE` to the required release and `FOUNDRY_IGNORE_AGE` to `"1"` when the cooling period is waived or `"0"` otherwise
-  * [ ] IF the Foundry workflow changes, confirm that `make install-foundry` and `make verify-foundry` use both CI settings
-  * [ ] IF the required release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
+  * **Phase 2 — Conditional CI synchronization**
+  * IF the required release differs from the recorded `FOUNDRY_RELEASE`
+    * [ ] Set `FOUNDRY_RELEASE` to the required release
+    * [ ] Set `FOUNDRY_IGNORE_AGE` to `"1"` only for an approved cooling-period waiver or `"0"` otherwise
+    * [ ] Confirm that `make install-foundry` and `make verify-foundry` use both CI settings
+  * **Phase 3 — Mandatory developer installation and verification**
+  * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
+    ```text
+    _Insert the complete installer output here_
+    ```
+  * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
     ```text
     _Insert the complete verifier output here_
     ```
-  * IF the verifier exits nonzero with `Required action: install`, the required release, and a matching `Installation command`
-    * [ ] Run the exact `Installation command` printed by the verifier
-      ```text
-      _Insert the complete installer output here_
-      ```
-    * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-    * [ ] Rerun the same exact-release verifier
-      ```text
-      _Insert the complete verifier output here_
-      ```
   * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
-  * IF any Foundry setup command exits nonzero other than the expected install response above
+  * **Phase 4 — Conditional failure handling**
+  * IF any Foundry setup command in Phases 1–3 exits nonzero, apply this recovery branch immediately
     * [ ] Stop Foundry setup
     * [ ] Record the failed command and complete output in the spell PR
     * [ ] Diagnose and resolve the failure
+    * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`; the failure does not authorize another automatic installation
     * [ ] Rerun the exact failed command
       ```text
       _Insert the complete command output here_

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -43,7 +43,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell
 * Verify and Install Foundry toolkit
-  * [ ] Record the exact Foundry release and optional age waiver used by both `make install-foundry` and `make verify-foundry` in `.github/workflows/tests.yaml`
+  * [ ] Record the exact Foundry release and optional age waiver used by both `make install-foundry` and `make verify-foundry` in [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml)
     ```text
     CI Foundry release: vMAJOR.MINOR.PATCH
     CI age waiver: None / ignore-age=1
@@ -100,9 +100,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Both spell reviewers reply to that comment with explicit approval
   * [ ] Confirm that the selected release has an `Acceptable` review outcome
   * [ ] Compare the selected release with the current CI Foundry release
-  * [ ] IF the selected release differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
+  * [ ] IF the selected release differs from the CI release, update both Foundry commands in [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml) to use `release=vMAJOR.MINOR.PATCH`
   * [ ] IF the selected release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in `.github/workflows/tests.yaml`; OTHERWISE remove `ignore-age=1`
+  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml); OTHERWISE remove `ignore-age=1`
   * [ ] Confirm that both CI commands use the same release and age-waiver arguments
   * [ ] IF the selected release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
     ```text

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -74,7 +74,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         * [ ] Treat the alternative as the release under review
         * [ ] Repeat the security and applicable compatibility checks above
       * [ ] Post the alternative version and upstream reference in the spell PR
-      * [ ] Obtain explicit approval from both spell reviewers
+      * [ ] Obtain explicit approval from both spell reviewers in follow-up comments
     * [ ] Record the passing selected release or passing explicitly approved alternative as the required release
       ```text
       Required release: vMAJOR.MINOR.PATCH

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -48,11 +48,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```text
       _Insert the complete selector output here_
       ```
-    * [ ] Copy the workflow-level Foundry settings from the local `.github/workflows/tests.yaml` into the block below
-      ```text
-      FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
-      FOUNDRY_IGNORE_AGE: 0 / 1
-      ```
     * [ ] Treat the selected release as the release under review
     * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release under review
     * [ ] IF an applicable advisory links an official Foundry incident notice, review that notice for unresolved issues affecting the release
@@ -60,6 +55,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       Security review: Unaffected / Affected / Applicability unclear
       Security advisories: _Insert URLs and outcome_
       Linked incident notices: None / _Insert URLs and outcome_
+      ```
+    * [ ] Copy the workflow-level Foundry settings from the local `.github/workflows/tests.yaml` into the block below
+      ```text
+      FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+      FOUNDRY_IGNORE_AGE: 0 / 1
       ```
     * [ ] IF adopting the release under review changes the workflow-level `FOUNDRY_RELEASE`, read its complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
       ```text

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -43,69 +43,69 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell
 * Verify and install the Foundry toolkit
-  * **Phase 1 — Mandatory release acceptance**
-  * [ ] Run `make select-foundry`
-    ```text
-    _Insert the complete selector output here_
-    ```
-  * [ ] Record the workflow-level Foundry settings from the local [`.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
-    ```text
-    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
-    FOUNDRY_IGNORE_AGE: 0 / 1
-    ```
-  * [ ] Treat the selected release as the release under review
-  * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the release under review
-    ```text
-    Security review: Unaffected / Affected / Applicability unclear
-    Sources and rationale: None affecting the release / _Insert URLs and outcome_
-    ```
-  * [ ] IF adopting the release under review changes the workflow-level `FOUNDRY_RELEASE`, read its complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
-    ```text
-    Release notes: _Insert exact release URL_
-    Compatibility: Compatible / Incompatible — _Insert rationale_
-    ```
-  * IF the release under review is affected, its applicability is unclear, or it is incompatible
-    * [ ] Stop Foundry setup and notify the spell team
-    * Repeat until the release under review is unaffected and, when compatibility is checked, compatible
-      * [ ] Select an exact alternative supported by an official upstream reference
-      * [ ] Treat the alternative as the release under review
-      * [ ] Repeat the security and applicable compatibility checks above
-    * [ ] Post the alternative version and upstream reference in the spell PR
-    * [ ] Obtain explicit approval from both spell reviewers
-  * [ ] Record the passing selected release, or the passing explicitly approved alternative, as the required release
-    ```text
-    Required release: vMAJOR.MINOR.PATCH
-    ```
-  * IF the required release is less than 14 days old
-    * [ ] Post a spell PR comment requesting an explicit cooling-period waiver
-    * [ ] Obtain explicit approval from both spell reviewers in follow-up comments
-  * **Phase 2 — Conditional CI synchronization**
-  * IF the required release differs from the recorded `FOUNDRY_RELEASE`
-    * [ ] Set `FOUNDRY_RELEASE` to the required release
-    * [ ] Set `FOUNDRY_IGNORE_AGE` to `"1"` only for an approved cooling-period waiver or `"0"` otherwise
-    * [ ] Confirm that `make install-foundry` and `make verify-foundry` use both CI settings
-  * **Phase 3 — Mandatory developer installation and verification**
-  * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
-    ```text
-    _Insert the complete installer output here_
-    ```
-  * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
-    ```text
-    _Insert the complete verifier output here_
-    ```
-  * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
-  * **Phase 4 — Conditional failure handling**
-  * IF any Foundry setup command in Phases 1–3 exits nonzero, apply this recovery branch immediately
-    * [ ] Stop Foundry setup
-    * [ ] Record the failed command and complete output in the spell PR
-    * [ ] Diagnose and resolve the failure
-    * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`; the failure does not authorize another automatic installation
-    * [ ] Rerun the exact failed command
+  * Phase 1 — Mandatory release acceptance
+    * [ ] Run `make select-foundry`
       ```text
-      _Insert the complete command output here_
+      _Insert the complete selector output here_
       ```
-    * [ ] IF the failure cannot be resolved, notify the spell team
+    * [ ] Record the workflow-level Foundry settings from the local [`.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
+      ```text
+      FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+      FOUNDRY_IGNORE_AGE: 0 / 1
+      ```
+    * [ ] Treat the selected release as the release under review
+    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the release under review
+      ```text
+      Security review: Unaffected / Affected / Applicability unclear
+      Sources and rationale: None affecting the release / _Insert URLs and outcome_
+      ```
+    * [ ] IF adopting the release under review changes the workflow-level `FOUNDRY_RELEASE`, read its complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
+      ```text
+      Release notes: _Insert exact release URL_
+      Compatibility: Compatible / Incompatible — _Insert rationale_
+      ```
+    * IF the release under review is affected, its applicability is unclear, or it is incompatible
+      * [ ] Stop Foundry setup and notify the spell team
+      * Repeat until the release under review is unaffected and, when compatibility is checked, compatible
+        * [ ] Select an exact alternative supported by an official upstream reference
+        * [ ] Treat the alternative as the release under review
+        * [ ] Repeat the security and applicable compatibility checks above
+      * [ ] Post the alternative version and upstream reference in the spell PR
+      * [ ] Obtain explicit approval from both spell reviewers
+    * [ ] Record the passing selected release, or the passing explicitly approved alternative, as the required release
+      ```text
+      Required release: vMAJOR.MINOR.PATCH
+      ```
+    * IF the required release is less than 14 days old
+      * [ ] Post a spell PR comment requesting an explicit cooling-period waiver
+      * [ ] Obtain explicit approval from both spell reviewers in follow-up comments
+  * Phase 2 — Conditional CI synchronization
+    * IF the required release differs from the recorded `FOUNDRY_RELEASE`
+      * [ ] Set `FOUNDRY_RELEASE` to the required release
+      * [ ] Set `FOUNDRY_IGNORE_AGE` to `"1"` only for an approved cooling-period waiver or `"0"` otherwise
+      * [ ] Confirm that `make install-foundry` and `make verify-foundry` use both CI settings
+  * Phase 3 — Mandatory developer installation and verification
+    * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
+      ```text
+      _Insert the complete installer output here_
+      ```
+    * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+    * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
+      ```text
+      _Insert the complete verifier output here_
+      ```
+    * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
+  * Phase 4 — Conditional failure handling
+    * IF any Foundry setup command in Phases 1–3 exits nonzero, apply this recovery branch immediately
+      * [ ] Stop Foundry setup
+      * [ ] Record the failed command and complete output in the spell PR
+      * [ ] Diagnose and resolve the failure
+      * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`; the failure does not authorize another automatic installation
+      * [ ] Rerun the exact failed command
+        ```text
+        _Insert the complete command output here_
+        ```
+      * [ ] IF the failure cannot be resolved, notify the spell team
 * Cleanup previous spell's actions
   * [ ] Check previous pull requests for the cleanup patterns
   * [ ] Delete unused dependencies in the `src/dependencies` folder IF applicable

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -5,29 +5,20 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 ## Development Stage
 
 * Install Foundry tooling
-  * [ ] Install the latest version of `foundryup` using one of the methods described in the official [Foundry installation docs](https://www.getfoundry.sh/introduction/installation)
-  * [ ] Install the stable Foundry version via `foundryup --install stable`
-    ```
-    Document the installed version below:
-    ```
-    * [ ] Check the `Build Timestamp` shown by `forge --version`
-      ```
-      Document the build timestamp below:
-      ```
-    * [ ] IF the installed stable version is less than 7 days old, install the previous stable version from the official [Foundry releases page](https://github.com/foundry-rs/foundry/releases) via `foundryup --install <version>`
-      ```
-      Document the selected release URL if pinning was needed below:
-      ```
-    * [ ] Do not use `foundryup --force`
-  * [ ] Verify attestations for the final installed Foundry binaries
+  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, install and verify Foundry
     ```bash
-    for bin in forge cast anvil chisel; do
-      gh attestation verify --owner foundry-rs "$(which "$bin")"
-    done
+    make install-foundry
     ```
-    ```
-    Document the attestation verification output below:
-    ```
+  * [ ] Confirm the installer exit status before continuing
+    * Exit `0`: installation and verification completed successfully
+    * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
+    * Any other nonzero exit: installation or verification failed. Resolve the failure before continuing
+  * [ ] Record the installer output as evidence:
+    * `spells-mainnet` source commit and installer SHA-256
+    * Selected Foundry release tag, publication timestamp, URL, and seven-day policy decision
+    * Archive attestation
+    * Installed versions
+    * Attestations for `forge`, `cast`, `anvil`, and `chisel`
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_
@@ -397,7 +388,7 @@ _Insert your local test logs here_
 ## Deployed Stage
 
 * Crafter's comment in the PR
-  * [ ] Contains relevant Foundry installation logs
+  * [ ] Contains the `spells-mainnet` source commit and installer SHA-256; selected Foundry release tag, publication timestamp, URL, and seven-day policy decision; archive attestation; installed versions; and attestations for `forge`, `cast`, `anvil`, and `chisel` (from above)
   * [ ] Contains a URL to the deployed spell
     * [ ] URL matches the spell address declared in `config.sol`
   * [ ] Contains a URL to the Tenderly Testnet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -13,21 +13,20 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```
   * OTHERWISE
     * IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-      * [ ] Record the desired release and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+      * [ ] Record the desired release
         ```text
         Desired release: vMAJOR.MINOR.PATCH
+        ```
+      * [ ] Check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+        ```text
         Security sources checked:
         Outstanding issues: None found / _Insert references_
         ```
-      * [ ] Record the complete initial verifier output
-        ```text
-        _Insert the complete initial verifier output here_
-        ```
-    * IF no unresolved issue affects the desired release
-      * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
-        ```text
-        _Insert the complete installer output here_
-        ```
+        * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
+          ```text
+          _Insert the complete installer output here_
+          ```
+        * [ ] OTHERWISE IF an unresolved issue affects the desired release, continue with Exceptional behavior below
       * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
       * [ ] Run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
         ```text

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -11,32 +11,53 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
-    * [ ] Confirm that the latest verifier reports `Required action: install`, the desired release, and the exact installation command; stop and diagnose any other failure
-    * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+    * [ ] IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, record the complete initial verifier output
       ```text
-      Desired release:
+      Initial verifier output:
+      _Insert the complete initial verifier output here_
+      ```
+    * [ ] IF the latest verifier reports `Required action: install`, record the desired release and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+      ```text
+      Desired release: vMAJOR.MINOR.PATCH
       Security sources checked:
       Outstanding issues: None found / _Insert references_
       ```
-    * IF an unresolved issue affects the desired release
-      * [ ] Stop and notify the spell team
-      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference, explicit spell-team approval, and exact release, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, then evaluate its output from the `IF`/`OTHERWISE` decision above
-        ```text
-        Upstream reference:
-        Spell-team approval:
-        Release: vMAJOR.MINOR.PATCH
-        ```
-    * [ ] IF no unresolved issue affects the release to install, run the exact installation command reported by the latest verifier
-    * [ ] Confirm that the installer succeeds; stop and resolve any failure
-    * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-    * [ ] IF installation was performed, rerun the same verifier command, confirm that it succeeds, and record the complete verifier and installer outputs
+    * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
       ```text
       Installer output:
       _Insert the complete installer output here_
-
-      Verifier output:
-      _Insert the complete verifier output here_
       ```
+    * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+    * [ ] IF the installer succeeds, run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
+      ```text
+      Final verifier output:
+      _Insert the complete final verifier output here_
+      ```
+    * Exceptional behavior
+      * [ ] IF the verifier fails without reporting `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, stop and diagnose the failure
+      * IF an unresolved issue affects the desired release
+        * [ ] Stop and notify the spell team
+        * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference, explicit spell-team approval, and exact release, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, and confirm that it either exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`
+          ```text
+          Upstream reference:
+          Spell-team approval:
+          Release: vMAJOR.MINOR.PATCH
+
+          Forced verifier output:
+          _Insert the complete forced verifier output here_
+          ```
+        * [ ] IF the forced verifier reports `Required action: install`, run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that the installer succeeds, and record the complete forced installer output
+          ```text
+          Forced installer output:
+          _Insert the complete forced installer output here_
+          ```
+        * [ ] IF the forced installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+        * [ ] IF forced installation was performed, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it exits `0`, and record the complete final forced verifier output
+          ```text
+          Final forced verifier output:
+          _Insert the complete final forced verifier output here_
+          ```
+      * [ ] IF an installer fails, stop and resolve the failure
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -6,24 +6,26 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 * Verify Foundry tooling
   * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and run `make verify-foundry`
-  * [ ] IF using a force release, record the upstream reference, explicit spell-team approval, and exact release tag, then run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1` instead
-    ```text
-    Upstream reference:
-    Spell-team approval:
-    Release: vMAJOR.MINOR.PATCH
-    ```
   * [ ] IF verification exits `0`, record the complete verifier output
     ```text
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
-    * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice; stop and notify the spell team if an unresolved issue affects that release
+    * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
       ```text
       Desired release:
       Security sources checked:
       Outstanding issues: None found / _Insert references_
       ```
-    * [ ] IF no unresolved issue affects the desired release, run the exact installation command reported by the verifier
+    * IF an unresolved issue affects the desired release
+      * [ ] Stop and notify the spell team
+      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference and explicit spell-team approval, then run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`
+        ```text
+        Upstream reference:
+        Spell-team approval:
+        Release: vMAJOR.MINOR.PATCH
+        ```
+    * [ ] IF no unresolved issue affects the release to install, run the exact installation command reported by the applicable verifier
     * [ ] Rerun the same verifier command, confirm that it exits `0`, and record the complete verifier and installer outputs
       ```text
       Installer output:

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -5,43 +5,44 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 ## Development Stage
 
 * Verify Foundry tooling
-  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and verify the Foundry binaries currently in PATH
+  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md)
+  * [ ] IF using the normal release policy, verify the Foundry binaries currently in PATH
     ```bash
     make verify-foundry
     ```
-  * [ ] Confirm the verifier exit status before continuing
-    * Exit `0`: verification completed successfully using the newest immutable stable release published at least 14 days ago
-    * Any nonzero exit: verification failed. Use one of the installation paths below before continuing
-  * IF verification failed
-    * Choose one installation path
-      * Default path
-        * [ ] Install and verify the eligible Foundry release
-          ```bash
-          make install-foundry
-          ```
-      * Urgent security-release exception
-        * [ ] Confirm that the release fixes a security issue that cannot wait for the 14-day cooling period
-        * [ ] Record the upstream security advisory or incident reference, the explicit spell-team approval, and the exact release tag
-          ```text
-          Upstream reference:
-          Spell-team approval:
-          Release: vMAJOR.MINOR.PATCH
-          ```
-        * [ ] Install and verify the approved release
-          ```bash
-          make install-foundry release=vMAJOR.MINOR.PATCH
-          ```
-    * [ ] Confirm the installer exit status
-      * Exit `0`: installation and verification completed successfully
-      * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
-      * Any other nonzero exit: installation or verification failed. Resolve the failure before continuing
-    * [ ] Record the installer output as evidence
-      ```
-      _Insert the complete installer output here_
-      ```
-    * [ ] Run the verifier matching the selected installation path and confirm that it exits `0`
-      * Default path: `make verify-foundry`
-      * Urgent exception: `make verify-foundry release=vMAJOR.MINOR.PATCH`
+  * [ ] IF using a force release that cannot wait for the 14-day cooling period, confirm that it fixes an urgent security issue and record the upstream reference, explicit spell-team approval, and exact release tag
+    ```text
+    Upstream reference:
+    Spell-team approval:
+    Release: vMAJOR.MINOR.PATCH
+    ```
+  * [ ] IF using a force release, verify the approved release instead of running the normal verifier command
+    ```bash
+    make verify-foundry release=vMAJOR.MINOR.PATCH force=1
+    ```
+  * [ ] Confirm the verifier exit status. Exit `0` means the installed release matches the desired release and no installation checks are required. Any nonzero exit means verification failed; continue only if the output reports a desired release and exact installation command, otherwise resolve the failure before continuing
+  * [ ] IF verification failed, record the desired release and installation command reported by the verifier
+    ```text
+    Desired install version:
+    Published at:
+    Release URL:
+    Installation command:
+    ```
+  * [ ] IF verification failed, check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the desired release's official notes, and any official incident notice linked from those sources for unresolved security issues affecting that release
+  * [ ] IF verification failed, record the version-specific security check as evidence
+    ```text
+    Checked at (UTC):
+    Sources checked:
+    Outstanding issues affecting the desired version: None found / _Insert references_
+    ```
+  * [ ] IF an unresolved security issue affects the desired release, stop, notify the spell team, and do not install or use that release
+  * [ ] IF verification failed and no unresolved security issue affects the desired release, run the exact installation command reported by the verifier
+  * [ ] IF installation ran, confirm the installer exit status: exit `0` means installation and verification completed successfully; exit `2` means installation and verification completed successfully but PATH setup is incomplete, so follow the exact export/profile instruction printed by the installer and start or use a shell with that PATH before continuing; any other nonzero exit means installation or verification failed and must be resolved before continuing
+  * [ ] IF installation ran, record the installer output as evidence
+    ```
+    _Insert the complete installer output here_
+    ```
+  * [ ] IF installation ran, rerun the same verifier command and confirm that it exits `0`
   * [ ] Record the final verifier output as evidence
     ```
     _Insert the complete verifier output here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -7,56 +7,32 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Verify Foundry tooling
   * [ ] Checkout `spells-mainnet` from a trusted, up-to-date source
   * [ ] Run `make verify-foundry`
-  * [ ] IF the latest verifier exits `0`, record the complete verifier output
-    ```text
-    _Insert the complete verifier output here_
-    ```
-  * OTHERWISE
-    * IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-      * [ ] Record the desired release
+  * IF the verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+    * [ ] Record the desired release
+      ```text
+      Desired release: vMAJOR.MINOR.PATCH
+      ```
+    * [ ] Check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+      ```text
+      Security sources checked:
+      Outstanding issues: None found / _Insert references_
+      ```
+    * [ ] IF an unresolved issue affects the desired release, continue with Exceptional behavior below
+    * [ ] OTHERWISE run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that it succeeds, and follow any `Required action: update-path` instructions
+    * [ ] Run `make verify-foundry` and confirm that it exits `0`
+  * Exceptional behavior
+    * [ ] IF the verifier fails without reporting `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, stop and diagnose the failure
+    * IF an unresolved issue affects the desired release
+      * [ ] Stop and notify the spell team
+      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, then record the upstream reference, explicit spell-team approval, and exact release
         ```text
-        Desired release: vMAJOR.MINOR.PATCH
+        Upstream reference:
+        Spell-team approval:
+        Release: vMAJOR.MINOR.PATCH
         ```
-      * [ ] Check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
-        ```text
-        Security sources checked:
-        Outstanding issues: None found / _Insert references_
-        ```
-        * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
-          ```text
-          _Insert the complete installer output here_
-          ```
-        * [ ] OTHERWISE IF an unresolved issue affects the desired release, continue with Exceptional behavior below
-      * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-      * [ ] Run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
-        ```text
-        _Insert the complete final verifier output here_
-        ```
-    * Exceptional behavior
-      * [ ] IF the verifier fails without reporting `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, stop and diagnose the failure
-      * IF an unresolved issue affects the desired release
-        * [ ] Stop and notify the spell team
-        * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, then record the upstream reference, explicit spell-team approval, and exact release
-          ```text
-          Upstream reference:
-          Spell-team approval:
-          Release: vMAJOR.MINOR.PATCH
-          ```
-        * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it either exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`, and record the complete forced verifier output
-          ```text
-          _Insert the complete forced verifier output here_
-          ```
-        * IF the forced verifier reports `Required action: install`
-          * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that the installer succeeds, and record the complete forced installer output
-            ```text
-            _Insert the complete forced installer output here_
-            ```
-          * [ ] IF the forced installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-          * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it exits `0`, and record the complete final forced verifier output
-            ```text
-            _Insert the complete final forced verifier output here_
-            ```
-      * [ ] IF an installer fails, stop and resolve the failure
+      * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1` and confirm that it exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`
+      * [ ] IF installation is required, run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, follow any `Required action: update-path` instructions, rerun the forced verifier, and confirm that it exits `0`
+    * [ ] IF an installer fails, stop and resolve the failure
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -469,13 +469,23 @@ _Insert your local test logs here_
   * [ ] Ensure newly added code is covered by tests
   * [ ] Check if chainlog needs to be updated
   * [ ] Copy over and redo "Tests" section from the above
+* Crafter's pre-deployment Foundry evidence in the spell PR
+  * [ ] Contains the exact `make verify-foundry release=vMAJOR.MINOR.PATCH` command, including `ignore-age=1` when it is present in CI
+  * [ ] Contains the complete verifier output
+  * [ ] Shows that the verifier exited `0`
+  * [ ] Shows that the desired and installed releases match the release pinned in CI
+* Independently verify the CI-pinned Foundry release
+  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when it is present in CI
+    ```text
+    _Insert the complete verifier output here_
+    ```
+  * [ ] Confirm that the verifier exits `0`
+  * [ ] Confirm that the desired and installed releases match the release pinned in CI
 * [ ] IF all checks pass, make sure to include explicit "Good to deploy" comment
 
 ## Deployed Stage
 
 * Crafter's comment in the PR
-  * [ ] Contains the output of the last `make verify-foundry` executed
-  * [ ] IF installation was performed, the comment contains the complete output from an execution of the exact `Installation command` printed by the verifier
   * [ ] Contains a URL to the deployed spell
     * [ ] URL matches the spell address declared in `config.sol`
   * [ ] Contains a URL to the Tenderly Testnet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -427,9 +427,9 @@ _Insert your local test logs here_
 ## Deployed Stage
 
 * Crafter's comment in the PR
-  * [ ] Contains the final verifier output
+  * [ ] Contains the output of the last `make verify-foundry` executed
   * IF installation was performed
-    * [ ] Contains the complete installer output, including the release asset attestation
+    * [ ] Contains the complete output of the last `make install-foundry release={vX.Y.Z}` executed
   * [ ] Contains a URL to the deployed spell
     * [ ] URL matches the spell address declared in `config.sol`
   * [ ] Contains a URL to the Tenderly Testnet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -7,6 +7,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Verify Foundry tooling
   * [ ] Checkout `spells-mainnet` from a trusted, up-to-date source
   * [ ] Run `make verify-foundry`
+    ```text
+    _Insert the complete verifier output here_
+    ```
   * IF the verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
     * [ ] Record the desired release
       ```text

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -12,16 +12,17 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
-    * [ ] IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, record the complete initial verifier output
-      ```text
-      _Insert the complete initial verifier output here_
-      ```
-    * [ ] IF the latest verifier reports `Required action: install`, record the desired release and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
-      ```text
-      Desired release: vMAJOR.MINOR.PATCH
-      Security sources checked:
-      Outstanding issues: None found / _Insert references_
-      ```
+    * IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+      * [ ] Record the desired release and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
+        ```text
+        Desired release: vMAJOR.MINOR.PATCH
+        Security sources checked:
+        Outstanding issues: None found / _Insert references_
+        ```
+      * [ ] Record the complete initial verifier output
+        ```text
+        _Insert the complete initial verifier output here_
+        ```
     * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
       ```text
       _Insert the complete installer output here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -4,8 +4,14 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 ## Development Stage
 
-* Verify Foundry tooling
-  * [ ] Checkout `spells-mainnet` from a trusted, up-to-date source
+* Prepare the `spells-mainnet` checkout
+  * [ ] Checkout the spell PR from a trusted local copy of the [`sky-ecosystem/spells-mainnet` repository](https://github.com/sky-ecosystem/spells-mainnet)
+* Verify and Install Foundry toolkit
+  * [ ] Record the exact Foundry release and optional age waiver used by both `make install-foundry` and `make verify-foundry` in `.github/workflows/tests.yaml`
+    ```text
+    CI Foundry release: vMAJOR.MINOR.PATCH
+    CI age waiver: None / ignore-age=1
+    ```
   * [ ] Run `make verify-foundry`
     ```text
     _Insert the complete verifier output here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -5,48 +5,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 ## Development Stage
 
 * Verify Foundry tooling
-  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md)
-  * [ ] IF using the normal release policy, verify the Foundry binaries currently in PATH
-    ```bash
-    make verify-foundry
-    ```
-  * [ ] IF using a force release that cannot wait for the 14-day cooling period, confirm that it fixes an urgent security issue and record the upstream reference, explicit spell-team approval, and exact release tag
-    ```text
-    Upstream reference:
-    Spell-team approval:
-    Release: vMAJOR.MINOR.PATCH
-    ```
-  * [ ] IF using a force release, verify the approved release instead of running the normal verifier command
-    ```bash
-    make verify-foundry release=vMAJOR.MINOR.PATCH force=1
-    ```
-  * [ ] Confirm the verifier exit status. Exit `0` means the installed release matches the desired release and no installation checks are required. Any nonzero exit means verification failed; continue only if the output reports a desired release and exact installation command, otherwise resolve the failure before continuing
-  * [ ] IF verification failed, record the desired release and installation command reported by the verifier
-    ```text
-    Desired install version:
-    Published at:
-    Release URL:
-    Installation command:
-    ```
-  * [ ] IF verification failed, check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the desired release's official notes, and any official incident notice linked from those sources for unresolved security issues affecting that release
-  * [ ] IF verification failed, record the version-specific security check as evidence
-    ```text
-    Checked at (UTC):
-    Sources checked:
-    Outstanding issues affecting the desired version: None found / _Insert references_
-    ```
-  * [ ] IF an unresolved security issue affects the desired release, stop, notify the spell team, and do not install or use that release
-  * [ ] IF verification failed and no unresolved security issue affects the desired release, run the exact installation command reported by the verifier
-  * [ ] IF installation ran, confirm the installer exit status: exit `0` means installation and verification completed successfully; exit `2` means installation and verification completed successfully but PATH setup is incomplete, so follow the exact export/profile instruction printed by the installer and start or use a shell with that PATH before continuing; any other nonzero exit means installation or verification failed and must be resolved before continuing
-  * [ ] IF installation ran, record the installer output as evidence
-    ```
-    _Insert the complete installer output here_
-    ```
-  * [ ] IF installation ran, rerun the same verifier command and confirm that it exits `0`
-  * [ ] Record the final verifier output as evidence
-    ```
-    _Insert the complete verifier output here_
-    ```
+  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and run `make verify-foundry`
+  * [ ] IF using a force release, record the upstream reference, explicit spell-team approval, and exact release tag, then run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1` instead
+  * [ ] IF verification reports a different desired release, check and record Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice; stop and notify the spell team if an unresolved issue affects that release
+  * [ ] IF verification reports a different desired release and no unresolved issue affects it, run the exact installation command reported by the verifier, then rerun the same verifier command
+  * [ ] Confirm that final verification exits `0` and record the complete verifier output plus installer output IF installation ran
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -10,34 +10,74 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete verifier output here_
     ```
-  * IF the verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-    * [ ] Record the desired release
-      ```text
-      Desired release: vMAJOR.MINOR.PATCH
-      ```
-    * [ ] Check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
-      ```text
-      Security sources checked:
-      Outstanding issues: None found / _Insert references_
-      ```
-    * [ ] IF an unresolved issue affects the desired release, continue with Exceptional behavior below
-    * [ ] OTHERWISE run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that it succeeds, and follow any `Required action: update-path` instructions
-    * [ ] Run `make verify-foundry` and confirm that it exits `0`
-  * Exceptional behavior
-    * [ ] IF the verifier fails without reporting `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, stop and diagnose the failure
-    * IF an unresolved issue affects the desired release
-      * [ ] Stop and notify the spell team
-      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, then record the upstream reference, explicit spell-team approval, and exact release
+  * IF the verifier fails
+    * IF any of these verifier output lines is missing:
+      * `Required action: install`
+      * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+      * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+      * [ ] Stop the workflow
+      * [ ] Diagnose the verifier failure
+    * OTHERWISE IF the failed verifier requires installation and reports both the desired release and its exact installation command
+      * Review official security sources for the release identified by the verifier
+        * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
+        * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the release
+        * [ ] Open every official advisory or incident notice linked from either source
+        * [ ] Read every linked official advisory or incident notice
+        * [ ] Determine whether each advisory or notice affects the release
+        * [ ] IF applicability is unresolved or unclear, treat the release as affected
         ```text
-        Upstream reference:
-        Spell-team approval:
-        Release: vMAJOR.MINOR.PATCH
+        Checked at (UTC):
+        Security advisories: _Insert URL and outcome_
+        Release notes: _Insert exact release URL and outcome_
+        Linked official notices: None / _Insert URLs and outcomes_
         ```
-      * [ ] IF the mitigation release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
-      * [ ] OTHERWISE confirm that the spell-team approval explicitly waives the 14-day cooling period, then run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
-      * [ ] Confirm that the exact-release verifier exits `0` or reports `Required action: install` and an exact `Installation command`
-      * [ ] IF installation is required, run the exact printed `Installation command`, follow any `Required action: update-path` instructions, rerun the same exact-release verifier, and confirm that it exits `0`
-    * [ ] IF an installer fails, stop and resolve the failure
+      * IF none of the checked sources identifies an unresolved issue affecting the desired release
+        * [ ] Run the exact `Installation command` printed by the verifier
+        * IF the installer fails
+          * [ ] Stop the workflow
+          * [ ] Resolve the installer failure
+        * OTHERWISE IF the installer succeeds
+          * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+          * [ ] Run `make verify-foundry`
+          * [ ] Confirm that the verifier exits `0`
+      * OTHERWISE IF the checked sources identify an unresolved issue affecting the desired release
+        * [ ] Stop the workflow
+        * [ ] Notify the spell team
+        * [ ] Identify an exact mitigation release
+        * [ ] Locate an official upstream reference showing that the mitigation release addresses the issue
+        * Review official security sources for the mitigation release
+          * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the mitigation release
+          * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the mitigation release
+          * [ ] Open every official advisory or incident notice linked from either source
+          * [ ] Read every linked official advisory or incident notice
+          * [ ] Determine whether each advisory or notice affects the mitigation release
+          * [ ] IF applicability is unresolved or unclear, treat the mitigation release as affected
+        * [ ] Obtain explicit spell-team approval for the mitigation release
+          ```text
+          Upstream reference:
+          Spell-team approval:
+          Release: vMAJOR.MINOR.PATCH
+          ```
+        * [ ] IF the mitigation release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
+        * OTHERWISE IF the mitigation release is less than 14 days old
+          * [ ] Confirm that the spell-team approval explicitly waives the 14-day cooling period
+          * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
+        * IF the exact-release verifier fails
+          * IF any of these exact-release verifier output requirements is missing:
+            * `Required action: install`
+            * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+            * `Installation command:` matching the mitigation release and including `ignore-age=1` when the cooling period is waived
+            * [ ] Stop the workflow
+            * [ ] Diagnose the verifier failure
+          * OTHERWISE IF the failed exact-release verifier requires installation for the mitigation release and prints a matching installation command
+            * [ ] Run the exact printed `Installation command`
+            * IF the installer fails
+              * [ ] Stop the workflow
+              * [ ] Resolve the installer failure
+            * OTHERWISE IF the installer succeeds
+              * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+              * [ ] Rerun the same exact-release verifier
+              * [ ] Confirm that the verifier exits `0`
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -401,7 +401,10 @@ _Insert your local test logs here_
 ## Deployed Stage
 
 * Crafter's comment in the PR
-  * [ ] Contains the final verifier output and, IF installation was performed, the installer output including the release asset attestation (from above)
+  * [ ] Contains the final verifier output
+  * IF installation was performed
+    * [ ] Contains the installer output
+    * [ ] Contains the release asset attestation (from above)
   * [ ] Contains a URL to the deployed spell
     * [ ] URL matches the spell address declared in `config.sol`
   * [ ] Contains a URL to the Tenderly Testnet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -11,7 +11,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
-    * [ ] Confirm that the latest verifier reports both the desired release and exact installation command; stop and diagnose any other failure
+    * [ ] Confirm that the latest verifier reports `Required action: install`, the desired release, and the exact installation command; stop and diagnose any other failure
     * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
       ```text
       Desired release:
@@ -27,10 +27,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         Release: vMAJOR.MINOR.PATCH
         ```
     * [ ] IF no unresolved issue affects the release to install, run the exact installation command reported by the latest verifier
-    * IF the installer exits `2`
-      * [ ] Follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-    * [ ] IF the installer exits with any other nonzero status, stop and resolve the failure
-    * [ ] IF installation was performed, rerun the same verifier command, confirm that it exits `0`, and record the complete verifier and installer outputs
+    * [ ] Confirm that the installer succeeds; stop and resolve any failure
+    * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+    * [ ] IF installation was performed, rerun the same verifier command, confirm that it succeeds, and record the complete verifier and installer outputs
       ```text
       Installer output:
       _Insert the complete installer output here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -5,7 +5,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 ## Development Stage
 
 * Verify Foundry tooling
-  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and run `make verify-foundry`
+  * [ ] Checkout `spells-mainnet` from a trusted, up-to-date source
+  * [ ] Run `make verify-foundry`
   * [ ] IF the latest verifier exits `0`, record the complete verifier output
     ```text
     _Insert the complete verifier output here_
@@ -13,7 +14,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * OTHERWISE
     * [ ] IF the latest verifier reports `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, record the complete initial verifier output
       ```text
-      Initial verifier output:
       _Insert the complete initial verifier output here_
       ```
     * [ ] IF the latest verifier reports `Required action: install`, record the desired release and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
@@ -24,13 +24,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```
     * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
       ```text
-      Installer output:
       _Insert the complete installer output here_
       ```
     * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
     * [ ] IF the installer succeeds, run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
       ```text
-      Final verifier output:
       _Insert the complete final verifier output here_
       ```
     * Exceptional behavior
@@ -43,18 +41,15 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
           Spell-team approval:
           Release: vMAJOR.MINOR.PATCH
 
-          Forced verifier output:
           _Insert the complete forced verifier output here_
           ```
         * [ ] IF the forced verifier reports `Required action: install`, run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that the installer succeeds, and record the complete forced installer output
           ```text
-          Forced installer output:
           _Insert the complete forced installer output here_
           ```
         * [ ] IF the forced installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
         * [ ] IF forced installation was performed, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it exits `0`, and record the complete final forced verifier output
           ```text
-          Final forced verifier output:
           _Insert the complete final forced verifier output here_
           ```
       * [ ] IF an installer fails, stop and resolve the failure

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -4,18 +4,31 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 ## Development Stage
 
-* Install Foundry tooling
-  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, install and verify Foundry
+* Verify Foundry tooling
+  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, verify the Foundry binaries currently in PATH
     ```bash
-    make install-foundry
+    make verify-foundry
     ```
-  * [ ] Confirm the installer exit status before continuing
-    * Exit `0`: installation and verification completed successfully
-    * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
-    * Any other nonzero exit: installation or verification failed. Resolve the failure before continuing
-  * [ ] Record the installer output as evidence:
+  * [ ] Confirm the verifier exit status before continuing
+    * Exit `0`: verification completed successfully using the newest stable release published at least seven days ago
+    * Any nonzero exit: verification failed. Install the eligible release before continuing
+  * IF verification failed
+    * [ ] Install and verify the eligible Foundry release
+      ```bash
+      make install-foundry
+      ```
+    * [ ] Confirm the installer exit status
+      * Exit `0`: installation and verification completed successfully
+      * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
+      * Any other nonzero exit: installation or verification failed. Resolve the failure before continuing
+    * [ ] Record the installer output as evidence
+      ```
+      _Insert the complete installer output here_
+      ```
+    * [ ] Run `make verify-foundry` again and confirm that it exits `0`
+  * [ ] Record the final verifier output as evidence
     ```
-    _Insert the complete installer output here_
+    _Insert the complete verifier output here_
     ```
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
@@ -386,7 +399,7 @@ _Insert your local test logs here_
 ## Deployed Stage
 
 * Crafter's comment in the PR
-  * [ ] Contains the `spells-mainnet` source commit and installer SHA-256; selected Foundry release tag, publication timestamp, URL, and seven-day policy decision; archive attestation; installed versions; and attestations for `forge`, `cast`, `anvil`, and `chisel` (from above)
+  * [ ] Contains the final verifier output and, IF installation was performed, the installer output including the release asset attestation (from above)
   * [ ] Contains a URL to the deployed spell
     * [ ] URL matches the spell address declared in `config.sol`
   * [ ] Contains a URL to the Tenderly Testnet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -11,13 +11,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete verifier output here_
     ```
   * IF the verifier fails
-    * IF any of these verifier output lines is missing:
+    * IF the failed verifier requires installation and reports all of:
       * `Required action: install`
       * `Desired Foundry release: vMAJOR.MINOR.PATCH`
       * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-      * [ ] Stop the workflow
-      * [ ] Diagnose the verifier failure
-    * OTHERWISE IF the failed verifier requires installation and reports both the desired release and its exact installation command
       * Review official security sources for the release identified by the verifier
         * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
         * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the release
@@ -33,13 +30,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         ```
       * IF none of the checked sources identifies an unresolved issue affecting the desired release
         * [ ] Run the exact `Installation command` printed by the verifier
-        * IF the installer fails
-          * [ ] Stop the workflow
-          * [ ] Resolve the installer failure
-        * OTHERWISE IF the installer succeeds
+        * IF the installer succeeds
           * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
           * [ ] Run `make verify-foundry`
           * [ ] Confirm that the verifier exits `0`
+        * OTHERWISE IF the installer fails
+          * [ ] Stop the workflow
+          * [ ] Resolve the installer failure
       * OTHERWISE IF the checked sources identify an unresolved issue affecting the desired release
         * [ ] Stop the workflow
         * [ ] Notify the spell team
@@ -63,21 +60,24 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
           * [ ] Confirm that the spell-team approval explicitly waives the 14-day cooling period
           * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
         * IF the exact-release verifier fails
-          * IF any of these exact-release verifier output requirements is missing:
+          * IF the failed exact-release verifier requires installation for the mitigation release and reports all of:
             * `Required action: install`
             * `Desired Foundry release: vMAJOR.MINOR.PATCH`
             * `Installation command:` matching the mitigation release and including `ignore-age=1` when the cooling period is waived
-            * [ ] Stop the workflow
-            * [ ] Diagnose the verifier failure
-          * OTHERWISE IF the failed exact-release verifier requires installation for the mitigation release and prints a matching installation command
             * [ ] Run the exact printed `Installation command`
-            * IF the installer fails
-              * [ ] Stop the workflow
-              * [ ] Resolve the installer failure
-            * OTHERWISE IF the installer succeeds
+            * IF the installer succeeds
               * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
               * [ ] Rerun the same exact-release verifier
               * [ ] Confirm that the verifier exits `0`
+            * OTHERWISE IF the installer fails
+              * [ ] Stop the workflow
+              * [ ] Resolve the installer failure
+          * OTHERWISE IF the exact-release verifier fails for any other reason
+            * [ ] Stop the workflow
+            * [ ] Diagnose the verifier failure
+    * OTHERWISE IF the verifier fails for any other reason
+      * [ ] Stop the workflow
+      * [ ] Diagnose the verifier failure
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -404,7 +404,7 @@ _Insert your local test logs here_
   * [ ] Contains the final verifier output
   * IF installation was performed
     * [ ] Contains the installer output
-    * [ ] Contains the release asset attestation (from above)
+    * [ ] Contains the release asset attestation
   * [ ] Contains a URL to the deployed spell
     * [ ] URL matches the spell address declared in `config.sol`
   * [ ] Contains a URL to the Tenderly Testnet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -6,11 +6,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 * Verify Foundry tooling
   * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and run `make verify-foundry`
-  * [ ] IF verification exits `0`, record the complete verifier output
+  * [ ] IF the latest verifier exits `0`, record the complete verifier output
     ```text
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
+    * [ ] Confirm that the latest verifier exits `3` and reports both the desired release and exact installation command; stop and diagnose any other result
     * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
       ```text
       Desired release:
@@ -19,14 +20,17 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```
     * IF an unresolved issue affects the desired release
       * [ ] Stop and notify the spell team
-      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference and explicit spell-team approval, then run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`
+      * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference, explicit spell-team approval, and exact release, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, then evaluate its output from the `IF`/`OTHERWISE` decision above
         ```text
         Upstream reference:
         Spell-team approval:
         Release: vMAJOR.MINOR.PATCH
         ```
-    * [ ] IF no unresolved issue affects the release to install, run the exact installation command reported by the applicable verifier
-    * [ ] Rerun the same verifier command, confirm that it exits `0`, and record the complete verifier and installer outputs
+    * [ ] IF no unresolved issue affects the release to install and the latest verifier exits `3`, run the exact installation command it reported
+    * IF the installer exits `2`
+      * [ ] Follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+    * [ ] IF the installer exits with any other nonzero status, stop and resolve the failure
+    * [ ] IF installation was performed, rerun the same verifier command, confirm that it exits `0`, and record the complete verifier and installer outputs
       ```text
       Installer output:
       _Insert the complete installer output here_
@@ -405,8 +409,7 @@ _Insert your local test logs here_
 * Crafter's comment in the PR
   * [ ] Contains the final verifier output
   * IF installation was performed
-    * [ ] Contains the installer output
-    * [ ] Contains the release asset attestation
+    * [ ] Contains the complete installer output, including the release asset attestation
   * [ ] Contains a URL to the deployed spell
     * [ ] URL matches the spell address declared in `config.sol`
   * [ ] Contains a URL to the Tenderly Testnet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -5,18 +5,32 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 ## Development Stage
 
 * Verify Foundry tooling
-  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, verify the Foundry binaries currently in PATH
+  * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and verify the Foundry binaries currently in PATH
     ```bash
     make verify-foundry
     ```
   * [ ] Confirm the verifier exit status before continuing
-    * Exit `0`: verification completed successfully using the newest stable release published at least seven days ago
-    * Any nonzero exit: verification failed. Install the eligible release before continuing
+    * Exit `0`: verification completed successfully using the newest immutable stable release published at least 14 days ago
+    * Any nonzero exit: verification failed. Use one of the installation paths below before continuing
   * IF verification failed
-    * [ ] Install and verify the eligible Foundry release
-      ```bash
-      make install-foundry
-      ```
+    * Choose one installation path
+      * Default path
+        * [ ] Install and verify the eligible Foundry release
+          ```bash
+          make install-foundry
+          ```
+      * Urgent security-release exception
+        * [ ] Confirm that the release fixes a security issue that cannot wait for the 14-day cooling period
+        * [ ] Record the upstream security advisory or incident reference, the explicit spell-team approval, and the exact release tag
+          ```text
+          Upstream reference:
+          Spell-team approval:
+          Release: vMAJOR.MINOR.PATCH
+          ```
+        * [ ] Install and verify the approved release
+          ```bash
+          make install-foundry release=vMAJOR.MINOR.PATCH
+          ```
     * [ ] Confirm the installer exit status
       * Exit `0`: installation and verification completed successfully
       * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
@@ -25,7 +39,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```
       _Insert the complete installer output here_
       ```
-    * [ ] Run `make verify-foundry` again and confirm that it exits `0`
+    * [ ] Run the verifier matching the selected installation path and confirm that it exits `0`
+      * Default path: `make verify-foundry`
+      * Urgent exception: `make verify-foundry release=vMAJOR.MINOR.PATCH`
   * [ ] Record the final verifier output as evidence
     ```
     _Insert the complete verifier output here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -23,36 +23,40 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         ```text
         _Insert the complete initial verifier output here_
         ```
-    * [ ] IF no unresolved issue affects the desired release, run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
-      ```text
-      _Insert the complete installer output here_
-      ```
-    * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-    * [ ] IF the installer succeeds, run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
-      ```text
-      _Insert the complete final verifier output here_
-      ```
+    * IF no unresolved issue affects the desired release
+      * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`, confirm that the installer succeeds, and record the complete installer output
+        ```text
+        _Insert the complete installer output here_
+        ```
+      * [ ] IF the installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+      * [ ] Run `make verify-foundry`, confirm that it exits `0`, and record the complete final verifier output
+        ```text
+        _Insert the complete final verifier output here_
+        ```
     * Exceptional behavior
       * [ ] IF the verifier fails without reporting `Required action: install`, the desired release, and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, stop and diagnose the failure
       * IF an unresolved issue affects the desired release
         * [ ] Stop and notify the spell team
-        * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, record the upstream reference, explicit spell-team approval, and exact release, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, and confirm that it either exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`
+        * [ ] Confirm that an exact mitigation release addresses the issue and has no unresolved issue, then record the upstream reference, explicit spell-team approval, and exact release
           ```text
           Upstream reference:
           Spell-team approval:
           Release: vMAJOR.MINOR.PATCH
-
+          ```
+        * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it either exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`, and record the complete forced verifier output
+          ```text
           _Insert the complete forced verifier output here_
           ```
-        * [ ] IF the forced verifier reports `Required action: install`, run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that the installer succeeds, and record the complete forced installer output
-          ```text
-          _Insert the complete forced installer output here_
-          ```
-        * [ ] IF the forced installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
-        * [ ] IF forced installation was performed, run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it exits `0`, and record the complete final forced verifier output
-          ```text
-          _Insert the complete final forced verifier output here_
-          ```
+        * IF the forced verifier reports `Required action: install`
+          * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that the installer succeeds, and record the complete forced installer output
+            ```text
+            _Insert the complete forced installer output here_
+            ```
+          * [ ] IF the forced installer reports `Required action: update-path`, follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
+          * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1`, confirm that it exits `0`, and record the complete final forced verifier output
+            ```text
+            _Insert the complete final forced verifier output here_
+            ```
       * [ ] IF an installer fails, stop and resolve the failure
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -14,11 +14,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * Exit `2`: installation and verification completed successfully, but PATH setup is incomplete. Follow the exact export/profile instruction printed by the installer, then start or use a shell with that PATH before continuing
     * Any other nonzero exit: installation or verification failed. Resolve the failure before continuing
   * [ ] Record the installer output as evidence:
-    * `spells-mainnet` source commit and installer SHA-256
-    * Selected Foundry release tag, publication timestamp, URL, and seven-day policy decision
-    * Archive attestation
-    * Installed versions
-    * Attestations for `forge`, `cast`, `anvil`, and `chisel`
+    ```
+    _Insert the complete installer output here_
+    ```
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -4,10 +4,29 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 ## Development Stage
 
-* Install stable Foundry version
-  * [ ] Install the stable version of Foundry via `foundryup --install stable`
+* Install Foundry tooling
+  * [ ] Install the latest version of `foundryup` using one of the methods described in the official [Foundry installation docs](https://www.getfoundry.sh/introduction/installation)
+  * [ ] Install the stable Foundry version via `foundryup --install stable`
     ```
-    Document the installation logs containing installed versions below:
+    Document the installed version below:
+    ```
+    * [ ] Check the `Build Timestamp` shown by `forge --version`
+      ```
+      Document the build timestamp below:
+      ```
+    * [ ] IF the installed stable version is less than 7 days old, install the previous stable version from the official [Foundry releases page](https://github.com/foundry-rs/foundry/releases) via `foundryup --install <version>`
+      ```
+      Document the selected release URL if pinning was needed below:
+      ```
+    * [ ] Do not use `foundryup --force`
+  * [ ] Verify attestations for the final installed Foundry binaries
+    ```bash
+    for bin in forge cast anvil chisel; do
+      gh attestation verify --owner foundry-rs "$(which "$bin")"
+    done
+    ```
+    ```
+    Document the attestation verification output below:
     ```
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -34,9 +34,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
           * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
           * [ ] Run `make verify-foundry`
           * [ ] Confirm that the verifier exits `0`
-        * OTHERWISE IF the installer fails
-          * [ ] Stop the workflow
-          * [ ] Resolve the installer failure
       * OTHERWISE IF the checked sources identify an unresolved issue affecting the desired release
         * [ ] Stop the workflow
         * [ ] Notify the spell team
@@ -69,15 +66,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
               * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
               * [ ] Rerun the same exact-release verifier
               * [ ] Confirm that the verifier exits `0`
-            * OTHERWISE IF the installer fails
-              * [ ] Stop the workflow
-              * [ ] Resolve the installer failure
-          * OTHERWISE IF the exact-release verifier fails for any other reason
-            * [ ] Stop the workflow
-            * [ ] Diagnose the verifier failure
-    * OTHERWISE IF the verifier fails for any other reason
-      * [ ] Stop the workflow
-      * [ ] Diagnose the verifier failure
+  * IF any `setup-foundry.sh` invocation exits nonzero without printing all of:
+    * `Required action: install`
+    * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+    * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when the cooling period is waived
+    * [ ] Stop the workflow
+    * [ ] Diagnose the failure
+    * [ ] Resolve the failure
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -11,7 +11,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete verifier output here_
     ```
   * OTHERWISE
-    * [ ] Confirm that the latest verifier exits `3` and reports both the desired release and exact installation command; stop and diagnose any other result
+    * [ ] Confirm that the latest verifier reports both the desired release and exact installation command; stop and diagnose any other failure
     * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice
       ```text
       Desired release:
@@ -26,7 +26,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         Spell-team approval:
         Release: vMAJOR.MINOR.PATCH
         ```
-    * [ ] IF no unresolved issue affects the release to install and the latest verifier exits `3`, run the exact installation command it reported
+    * [ ] IF no unresolved issue affects the release to install, run the exact installation command reported by the latest verifier
     * IF the installer exits `2`
       * [ ] Follow the exact PATH instructions it prints and start or use a shell with the updated PATH before continuing
     * [ ] IF the installer exits with any other nonzero status, stop and resolve the failure

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -10,42 +10,60 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete verifier output here_
     ```
-  * IF the verifier fails
-    * IF the failed verifier requires installation and reports all of:
-      * `Required action: install`
-      * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-      * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-      * Review official security sources for the release identified by the verifier
-        * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
-        * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the release
-        * [ ] Open every official advisory or incident notice linked from either source
-        * [ ] Read every linked official advisory or incident notice
-        * [ ] Determine whether each advisory or notice affects the release
-        * [ ] IF applicability is unresolved or unclear, treat the release as affected
+  * IF the verifier fails with `Required action: install` and reports:
+    * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+    * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+    * Review official security sources for the release identified by the verifier
+      * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
         ```text
         Checked at (UTC):
         Security advisories: _Insert URL and outcome_
+        ```
+      * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the release
+        ```text
+        Checked at (UTC):
         Release notes: _Insert exact release URL and outcome_
+        ```
+      * [ ] Review every official advisory or incident notice linked from either source for applicability to the desired release
+        ```text
+        Checked at (UTC):
         Linked official notices: None / _Insert URLs and outcomes_
         ```
-      * IF none of the checked sources identifies an unresolved issue affecting the desired release
-        * [ ] Run the exact `Installation command` printed by the verifier
-        * IF the installer succeeds
-          * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-          * [ ] Run `make verify-foundry`
-          * [ ] Confirm that the verifier exits `0`
-      * OTHERWISE IF the checked sources identify an unresolved issue affecting the desired release
-        * [ ] Stop the workflow
-        * [ ] Notify the spell team
-        * [ ] Identify an exact mitigation release
-        * [ ] Locate an official upstream reference showing that the mitigation release addresses the issue
-        * Review official security sources for the mitigation release
-          * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the mitigation release
-          * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the mitigation release
-          * [ ] Open every official advisory or incident notice linked from either source
-          * [ ] Read every linked official advisory or incident notice
-          * [ ] Determine whether each advisory or notice affects the mitigation release
-          * [ ] IF applicability is unresolved or unclear, treat the mitigation release as affected
+      * [ ] IF applicability is unresolved or unclear, treat the release as affected
+    * IF the security review finds no unresolved issue affecting the desired release
+      * [ ] Run the exact `Installation command` printed by the verifier
+        ```text
+        _Insert the complete installer output here_
+        ```
+      * IF the installer succeeds
+        * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+        * [ ] Run `make verify-foundry`
+          ```text
+          _Insert the complete verifier output here_
+          ```
+        * [ ] Confirm that the verifier exits `0`
+    * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the desired release
+      * [ ] Notify the spell team
+      * [ ] Identify an exact mitigation release
+      * [ ] Locate an official upstream reference showing that the mitigation release addresses the issue
+      * Review official security sources for the mitigation release
+        * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the mitigation release
+          ```text
+          Checked at (UTC):
+          Security advisories: _Insert URL and outcome_
+          ```
+        * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the mitigation release
+          ```text
+          Checked at (UTC):
+          Release notes: _Insert exact release URL and outcome_
+          ```
+        * [ ] Review every official advisory or incident notice linked from either source for applicability to the mitigation release
+          ```text
+          Checked at (UTC):
+          Linked official notices: None / _Insert URLs and outcomes_
+          ```
+        * [ ] IF applicability is unresolved or unclear, treat the mitigation release as affected
+      * IF the security review finds no unresolved issue affecting the mitigation release
         * [ ] Obtain explicit spell-team approval for the mitigation release
           ```text
           Upstream reference:
@@ -53,20 +71,32 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
           Release: vMAJOR.MINOR.PATCH
           ```
         * [ ] IF the mitigation release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
+          ```text
+          _Insert the complete verifier output here_
+          ```
         * OTHERWISE IF the mitigation release is less than 14 days old
           * [ ] Confirm that the spell-team approval explicitly waives the 14-day cooling period
           * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
-        * IF the exact-release verifier fails
-          * IF the failed exact-release verifier requires installation for the mitigation release and reports all of:
-            * `Required action: install`
-            * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-            * `Installation command:` matching the mitigation release and including `ignore-age=1` when the cooling period is waived
-            * [ ] Run the exact printed `Installation command`
-            * IF the installer succeeds
-              * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-              * [ ] Rerun the same exact-release verifier
-              * [ ] Confirm that the verifier exits `0`
-  * IF any `setup-foundry.sh` invocation exits nonzero without printing all of:
+            ```text
+            _Insert the complete verifier output here_
+            ```
+        * IF the exact-release verifier fails with `Required action: install` for the mitigation release and reports:
+          * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+          * `Installation command:` matching the mitigation release and including `ignore-age=1` when the cooling period is waived
+          * [ ] Run the exact printed `Installation command`
+            ```text
+            _Insert the complete installer output here_
+            ```
+          * IF the installer succeeds
+            * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+            * [ ] Rerun the same exact-release verifier
+              ```text
+              _Insert the complete verifier output here_
+              ```
+            * [ ] Confirm that the verifier exits `0`
+      * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the mitigation release
+        * [ ] Stop the workflow
+  * IF either `make verify-foundry` or `make install-foundry` exits nonzero without printing all of:
     * `Required action: install`
     * `Desired Foundry release: vMAJOR.MINOR.PATCH`
     * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when the cooling period is waived
@@ -443,8 +473,7 @@ _Insert your local test logs here_
 
 * Crafter's comment in the PR
   * [ ] Contains the output of the last `make verify-foundry` executed
-  * IF installation was performed
-    * [ ] Contains the complete output of the last `make install-foundry release={vX.Y.Z}` executed
+  * [ ] IF installation was performed, the comment contains the complete output from an execution of the exact `Installation command` printed by the verifier
   * [ ] Contains a URL to the deployed spell
     * [ ] URL matches the spell address declared in `config.sol`
   * [ ] Contains a URL to the Tenderly Testnet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -16,99 +16,95 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete verifier output here_
     ```
-  * IF the verifier fails with `Required action: install` and reports:
-    * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-    * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-    * Review official security sources for the release identified by the verifier
-      * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
+  * IF the verifier exits nonzero, confirm that it reports:
+    * [ ] `Required action: install`
+    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH`
+    * [ ] `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+  * [ ] Record the verifier's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the first candidate release
+  * Review each exact candidate release
+    * Confirm from the candidate's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
+      * [ ] The release is not a draft
+      * [ ] The release is not a prerelease
+      * [ ] The release is marked immutable
+      ```text
+      Release metadata: _Insert exact release URL and outcome_
+      ```
+    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) to confirm that no affected version range includes the candidate
+      ```text
+      Security advisories: _Insert URL and outcome_
+      ```
+    * [ ] Read the candidate's complete [release notes](https://github.com/foundry-rs/foundry/releases) and identify every breaking change
+      ```text
+      Release notes: _Insert exact release URL_
+      Breaking changes: None / _Insert breaking changes_
+      ```
+    * [ ] Determine whether the breaking changes are compatible with spell building, testing, and deployment
+      ```text
+      Compatibility outcome: Compatible / Incompatible
+      ```
+    * [ ] IF a security advisory or the release notes link to a supplemental official advisory or incident notice, read it and determine its applicability and remediation
+      ```text
+      Linked official notices: None / _Insert URLs and applicability or remediation outcomes_
+      ```
+    * [ ] Record whether the candidate is acceptable
+      ```text
+      Candidate release: vMAJOR.MINOR.PATCH
+      Outcome: Acceptable / Affected / Applicability unclear / Incompatible
+      ```
+  * IF the candidate is affected, its applicability is unclear, or it has an incompatible breaking change
+    * [ ] Notify the spell team
+    * [ ] Identify an exact alternative release, either older or newer
+    * [ ] Locate an official upstream reference showing that the alternative is unaffected or addresses the issue
+    * [ ] Repeat the exact candidate-release review above for the alternative
+  * IF an alternative release is selected
+    * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
+    * [ ] Obtain explicit spell-team approval in a reply to that comment or another spell PR comment
+  * [ ] Confirm that the selected candidate has an `Acceptable` review outcome
+  * [ ] Compare the selected candidate with the current CI Foundry release
+  * [ ] IF the selected candidate differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
+  * [ ] IF the selected candidate is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
+  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in `.github/workflows/tests.yaml`
+  * [ ] IF no cooling-period waiver applies, remove `ignore-age=1` from both Foundry commands in `.github/workflows/tests.yaml`
+  * [ ] Confirm that both CI commands use the same release and age-waiver arguments
+  * The CI release remains pinned until a later approved release replaces it
+  * [ ] IF the selected candidate is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
+    ```text
+    _Insert the complete verifier output here_
+    ```
+  * [ ] OTHERWISE IF the selected candidate is less than 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
+    ```text
+    _Insert the complete verifier output here_
+    ```
+  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the selected candidate
+  * OTHERWISE IF the exact-release verifier fails with `Required action: install` and reports:
+    * `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the selected candidate
+    * `Installation command:` matching the selected candidate and including `ignore-age=1` when the cooling period is waived
+    * [ ] Run the exact `Installation command` printed by the verifier
+      ```text
+      _Insert the complete installer output here_
+      ```
+    * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+    * IF the installer exits `0`
+      * [ ] Rerun the same exact-release verifier
         ```text
-        Checked at (UTC):
-        Security advisories: _Insert URL and outcome_
+        _Insert the complete verifier output here_
         ```
-      * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the release
-        ```text
-        Checked at (UTC):
-        Release notes: _Insert exact release URL and outcome_
-        ```
-      * [ ] Review every official advisory or incident notice linked from either source for applicability to the desired release
-        ```text
-        Checked at (UTC):
-        Linked official notices: None / _Insert URLs and outcomes_
-        ```
-      * [ ] IF applicability is unresolved or unclear, treat the release as affected
-    * IF the security review finds no unresolved issue affecting the desired release
-      * [ ] Run the exact `Installation command` printed by the verifier
-        ```text
-        _Insert the complete installer output here_
-        ```
-      * IF the installer succeeds
-        * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-        * [ ] Run `make verify-foundry`
-          ```text
-          _Insert the complete verifier output here_
-          ```
-        * [ ] Confirm that the verifier exits `0`
-    * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the desired release
-      * [ ] Notify the spell team
-      * [ ] Identify an exact mitigation release
-      * [ ] Locate an official upstream reference showing that the mitigation release addresses the issue
-      * Review official security sources for the mitigation release
-        * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the mitigation release
-          ```text
-          Checked at (UTC):
-          Security advisories: _Insert URL and outcome_
-          ```
-        * [ ] Read the complete [release notes](https://github.com/foundry-rs/foundry/releases) for the mitigation release
-          ```text
-          Checked at (UTC):
-          Release notes: _Insert exact release URL and outcome_
-          ```
-        * [ ] Review every official advisory or incident notice linked from either source for applicability to the mitigation release
-          ```text
-          Checked at (UTC):
-          Linked official notices: None / _Insert URLs and outcomes_
-          ```
-        * [ ] IF applicability is unresolved or unclear, treat the mitigation release as affected
-      * IF the security review finds no unresolved issue affecting the mitigation release
-        * [ ] Obtain explicit spell-team approval for the mitigation release
-          ```text
-          Upstream reference:
-          Spell-team approval:
-          Release: vMAJOR.MINOR.PATCH
-          ```
-        * [ ] IF the mitigation release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
-          ```text
-          _Insert the complete verifier output here_
-          ```
-        * OTHERWISE IF the mitigation release is less than 14 days old
-          * [ ] Confirm that the spell-team approval explicitly waives the 14-day cooling period
-          * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
-            ```text
-            _Insert the complete verifier output here_
-            ```
-        * IF the exact-release verifier fails with `Required action: install` for the mitigation release and reports:
-          * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-          * `Installation command:` matching the mitigation release and including `ignore-age=1` when the cooling period is waived
-          * [ ] Run the exact printed `Installation command`
-            ```text
-            _Insert the complete installer output here_
-            ```
-          * IF the installer succeeds
-            * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-            * [ ] Rerun the same exact-release verifier
-              ```text
-              _Insert the complete verifier output here_
-              ```
-            * [ ] Confirm that the verifier exits `0`
-      * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the mitigation release
-        * [ ] Stop the workflow
-  * IF either `make verify-foundry` or `make install-foundry` exits nonzero without printing all of:
-    * `Required action: install`
-    * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-    * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when the cooling period is waived
-    * [ ] Stop the workflow
+      * [ ] Confirm that the verifier exits `0`
+  * IF either unexpected Foundry setup failure occurs:
+    * A `make verify-foundry` invocation exits nonzero without:
+      * `Required action: install`
+      * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+      * `Installation command:` matching the desired release and including `ignore-age=1` when the cooling period is waived
+    * A `make install-foundry` invocation exits nonzero
+    * [ ] Record the failed command and complete output in the spell PR
+    * [ ] Stop Foundry setup
     * [ ] Diagnose the failure
     * [ ] Resolve the failure
+    * [ ] Rerun the exact failed command
+      ```text
+      _Insert the complete command output here_
+      ```
+    * [ ] IF the failure cannot be resolved, notify the spell team
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -33,8 +33,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         Spell-team approval:
         Release: vMAJOR.MINOR.PATCH
         ```
-      * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1` and confirm that it exits `0` or reports `Required action: install` and `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH force=1`
-      * [ ] IF installation is required, run `make install-foundry release=vMAJOR.MINOR.PATCH force=1`, follow any `Required action: update-path` instructions, rerun the forced verifier, and confirm that it exits `0`
+      * [ ] IF the mitigation release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
+      * [ ] OTHERWISE confirm that the spell-team approval explicitly waives the 14-day cooling period, then run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
+      * [ ] Confirm that the exact-release verifier exits `0` or reports `Required action: install` and an exact `Installation command`
+      * [ ] IF installation is required, run the exact printed `Installation command`, follow any `Required action: update-path` instructions, rerun the same exact-release verifier, and confirm that it exits `0`
     * [ ] IF an installer fails, stop and resolve the failure
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -7,9 +7,31 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Verify Foundry tooling
   * [ ] From a trusted, up-to-date checkout of `spells-mainnet`, review the [Foundry setup security model](https://github.com/sky-ecosystem/spells-mainnet/blob/master/scripts/setup-foundry/README.md) and run `make verify-foundry`
   * [ ] IF using a force release, record the upstream reference, explicit spell-team approval, and exact release tag, then run `make verify-foundry release=vMAJOR.MINOR.PATCH force=1` instead
-  * [ ] IF verification reports a different desired release, check and record Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice; stop and notify the spell team if an unresolved issue affects that release
-  * [ ] IF verification reports a different desired release and no unresolved issue affects it, run the exact installation command reported by the verifier, then rerun the same verifier command
-  * [ ] Confirm that final verification exits `0` and record the complete verifier output plus installer output IF installation ran
+    ```text
+    Upstream reference:
+    Spell-team approval:
+    Release: vMAJOR.MINOR.PATCH
+    ```
+  * [ ] IF verification exits `0`, record the complete verifier output
+    ```text
+    _Insert the complete verifier output here_
+    ```
+  * OTHERWISE
+    * [ ] Record the desired release reported by the verifier and check Foundry's official [security advisories](https://github.com/foundry-rs/foundry/security/advisories), the release notes, and any linked official incident notice; stop and notify the spell team if an unresolved issue affects that release
+      ```text
+      Desired release:
+      Security sources checked:
+      Outstanding issues: None found / _Insert references_
+      ```
+    * [ ] IF no unresolved issue affects the desired release, run the exact installation command reported by the verifier
+    * [ ] Rerun the same verifier command, confirm that it exits `0`, and record the complete verifier and installer outputs
+      ```text
+      Installer output:
+      _Insert the complete installer output here_
+
+      Verifier output:
+      _Insert the complete verifier output here_
+      ```
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -15,11 +15,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```text
       _Insert the complete selector output here_
       ```
-    * [ ] Copy the workflow-level Foundry settings from the checked-out spell PR's `.github/workflows/tests.yaml` into the block below
-      ```text
-      FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
-      FOUNDRY_IGNORE_AGE: 0 / 1
-      ```
     * [ ] Treat the selected release as the release under review
     * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release under review
     * [ ] IF an applicable advisory links an official Foundry incident notice, review that notice for unresolved issues affecting the release
@@ -27,6 +22,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       Security review: Unaffected / Affected / Applicability unclear
       Security advisories: _Insert URLs and outcome_
       Linked incident notices: None / _Insert URLs and outcome_
+      ```
+    * [ ] Copy the workflow-level Foundry settings from the checked-out spell PR's `.github/workflows/tests.yaml` into the block below
+      ```text
+      FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+      FOUNDRY_IGNORE_AGE: 0 / 1
       ```
     * [ ] IF the spell PR changes `FOUNDRY_RELEASE`, read the release under review's complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
       ```text

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -10,7 +10,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     gh pr checkout PR_NUMBER
     ```
 * Verify and Install Foundry toolkit
-  * [ ] Record the exact Foundry release and optional age waiver used by both `make install-foundry` and `make verify-foundry` in `.github/workflows/tests.yaml`
+  * [ ] Record the exact Foundry release and optional age waiver used by both `make install-foundry` and `make verify-foundry` in [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml)
     ```text
     CI Foundry release: vMAJOR.MINOR.PATCH
     CI age waiver: None / ignore-age=1
@@ -67,9 +67,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Both spell reviewers reply to that comment with explicit approval
   * [ ] Confirm that the selected release has an `Acceptable` review outcome
   * [ ] Compare the selected release with the current CI Foundry release
-  * [ ] IF the selected release differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
+  * [ ] IF the selected release differs from the CI release, update both Foundry commands in [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml) to use `release=vMAJOR.MINOR.PATCH`
   * [ ] IF the selected release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in `.github/workflows/tests.yaml`; OTHERWISE remove `ignore-age=1`
+  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml); OTHERWISE remove `ignore-age=1`
   * [ ] Confirm that both CI commands use the same release and age-waiver arguments
   * [ ] IF the selected release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
     ```text

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -41,15 +41,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         * [ ] Treat the alternative as the release under review
         * [ ] Repeat the security and applicable compatibility checks above
       * [ ] Confirm that the spell PR identifies the alternative and its upstream reference
-      * [ ] Confirm that both spell reviewers explicitly approved the alternative in follow-up comments
+      * [ ] IF the alternative is less than 14 days old, confirm that the same comment requests an explicit cooling-period waiver
+      * [ ] Approve the alternative and, IF applicable, its cooling-period waiver in a follow-up comment
+      * [ ] Confirm that the other spell reviewer approved the alternative and, IF applicable, its cooling-period waiver in a follow-up comment
     * [ ] Record the passing selected release or passing explicitly approved alternative as the required release
       ```text
       Required release: vMAJOR.MINOR.PATCH
       ```
-    * IF the required release is less than 14 days old
-      * [ ] Confirm that the spell PR contains a comment requesting an explicit cooling-period waiver
-      * [ ] Approve the waiver in a follow-up comment
-      * [ ] Confirm that the other spell reviewer approved the waiver in a follow-up comment
   * Phase 2 — Conditional CI synchronization
     * IF the spell PR changes `FOUNDRY_RELEASE`
       * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -41,7 +41,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         * [ ] Treat the alternative as the release under review
         * [ ] Repeat the security and applicable compatibility checks above
       * [ ] Confirm that the spell PR identifies the alternative and its upstream reference
-      * [ ] Confirm that both spell reviewers explicitly approved the alternative
+      * [ ] Confirm that both spell reviewers explicitly approved the alternative in follow-up comments
     * [ ] Record the passing selected release or passing explicitly approved alternative as the required release
       ```text
       Required release: vMAJOR.MINOR.PATCH

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -6,14 +6,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 * Verify Foundry tooling
   * [ ] Checkout `spells-mainnet` from a trusted, up-to-date source
-  * [ ] Run `make verify-foundry`
+  * [ ] Run `make select-foundry`
     ```text
-    _Insert the complete verifier output here_
+    _Insert the complete selector output here_
     ```
-  * IF the verifier fails with `Required action: install` and reports:
+  * IF the selector succeeds and reports:
     * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-    * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-    * Review official security sources for the release identified by the verifier
+    * Review official security sources for the release identified by the selector
       * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release
         ```text
         Checked at (UTC):
@@ -31,17 +30,25 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         ```
       * [ ] IF applicability is unresolved or unclear, treat the release as affected
     * IF the security review finds no unresolved issue affecting the desired release
-      * [ ] Run the exact `Installation command` printed by the verifier
+      * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`
         ```text
-        _Insert the complete installer output here_
+        _Insert the complete verifier output here_
         ```
-      * IF the installer succeeds
-        * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-        * [ ] Run `make verify-foundry`
+      * [ ] IF the verifier succeeds, confirm that it exits `0`
+      * OTHERWISE IF the verifier fails with `Required action: install` and reports:
+        * `Desired Foundry release: vMAJOR.MINOR.PATCH`
+        * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
+        * [ ] Run the exact `Installation command` printed by the verifier
           ```text
-          _Insert the complete verifier output here_
+          _Insert the complete installer output here_
           ```
-        * [ ] Confirm that the verifier exits `0`
+        * IF the installer succeeds
+          * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+          * [ ] Rerun `make verify-foundry release=vMAJOR.MINOR.PATCH`
+            ```text
+            _Insert the complete verifier output here_
+            ```
+          * [ ] Confirm that the verifier exits `0`
     * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the desired release
       * [ ] Notify the spell team
       * [ ] Identify an exact mitigation release
@@ -96,7 +103,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
             * [ ] Confirm that the verifier exits `0`
       * OTHERWISE IF the security review finds an unresolved issue or unclear applicability for the mitigation release
         * [ ] Stop the workflow
-  * IF either `make verify-foundry` or `make install-foundry` exits nonzero without printing all of:
+  * IF `make select-foundry` exits nonzero or does not report `Desired Foundry release: vMAJOR.MINOR.PATCH`
+    * [ ] Stop the workflow
+    * [ ] Diagnose the failure
+    * [ ] Resolve the failure
+  * OTHERWISE IF either `make verify-foundry` or `make install-foundry` exits nonzero without printing all of:
     * `Required action: install`
     * `Desired Foundry release: vMAJOR.MINOR.PATCH`
     * `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when the cooling period is waived

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -10,7 +10,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     gh pr checkout PR_NUMBER
     ```
 * Verify and Install Foundry toolkit
-  * [ ] Record the workflow-level Foundry settings from [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml)
+  * [ ] Record the workflow-level Foundry settings from [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
     ```text
     FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
     FOUNDRY_IGNORE_AGE: 0 / 1
@@ -67,9 +67,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Both spell reviewers reply to that comment with explicit approval
   * [ ] Confirm that the selected release has an `Acceptable` review outcome
   * [ ] Compare the selected release with the current `FOUNDRY_RELEASE`
-  * [ ] IF the selected release differs from the CI release, update `FOUNDRY_RELEASE` in [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml)
+  * [ ] IF the selected release differs from the CI release, update `FOUNDRY_RELEASE` in [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
   * [ ] IF the selected release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] IF the cooling-period waiver applies, set `FOUNDRY_IGNORE_AGE` to `"1"` in [`.github/workflows/tests.yaml`](../.github/workflows/tests.yaml); OTHERWISE set it to `"0"`
+  * [ ] IF the cooling-period waiver applies, set `FOUNDRY_IGNORE_AGE` to `"1"` in [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml); OTHERWISE set it to `"0"`
   * [ ] Confirm that `make install-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
   * [ ] Confirm that `make verify-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
   * [ ] IF the selected release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -9,13 +9,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```bash
     gh pr checkout PR_NUMBER
     ```
-* Review Foundry setup changes before execution
+* Confirm that Foundry setup changes are handled separately
   * IF the spell PR changes `Makefile` or any repository-controlled file loaded or executed by a Foundry setup target, including files under `scripts/setup-foundry/`
-    * [ ] Confirm that the spell PR documents the purpose of the changes
-    * [ ] Inspect the complete diff for those changes before running any Foundry setup command
-    * IF the purpose is undocumented or any concern remains unresolved
-      * [ ] Stop Foundry setup
-      * [ ] Notify the spell team
+    * [ ] Stop Foundry setup
+    * [ ] Ask the spell team to move the Foundry setup changes to a separate maintenance PR
+    * [ ] Resume only after the maintenance PR is merged and the spell PR is updated
 * Verify and install the Foundry toolkit
   * Phase 1 — Mandatory release acceptance
     * [ ] Run `make select-foundry`
@@ -23,13 +21,15 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       _Insert the complete selector output here_
       ```
     * [ ] Treat the selected release as the release under review
-    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release under review
-    * [ ] IF an applicable advisory links an official Foundry incident notice, review that notice for unresolved issues affecting the release
-      ```text
-      Security review: Unaffected / Affected / Applicability unclear
-      Security advisories: _Insert URLs and outcome_
-      Linked incident notices: None / _Insert URLs and outcome_
-      ```
+    * Review the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
+      * [ ] Read each potentially applicable advisory and determine whether its affected version range includes the release
+      * [ ] Review every official upstream advisory or incident notice linked from an applicable advisory for unresolved issues affecting the release
+      * [ ] Record the security review evidence
+        ```text
+        Security review: Unaffected / Affected / Applicability unclear
+        Security advisories: None affecting the release / _Insert URLs and outcome_
+        Linked official sources: None / _Insert URLs and outcome_
+        ```
     * [ ] Copy the workflow-level Foundry settings from the checked-out spell PR's `.github/workflows/tests.yaml` into the block below
       ```text
       FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
@@ -47,10 +47,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         * [ ] Select an exact alternative supported by an official upstream reference
         * [ ] Treat the alternative as the release under review
         * [ ] Repeat the security and applicable compatibility checks above
-      * [ ] Confirm that the spell PR identifies the alternative and its upstream reference
-      * [ ] IF the alternative is less than 14 days old, confirm that the same comment requests an explicit cooling-period waiver
-      * [ ] Approve the alternative and, IF applicable, its cooling-period waiver in a follow-up comment
-      * [ ] Confirm that the other spell reviewer approved the alternative and, IF applicable, its cooling-period waiver in a follow-up comment
+      * Crafter's alternative-release comment
+        * [ ] Contains the exact alternative release to install and its upstream reference
+        * [ ] IF the alternative is less than 14 days old, contains an explicit cooling-period waiver request
+      * [ ] Approve the alternative and, IF applicable, its cooling-period waiver in a reply to that comment
+      * [ ] Confirm that the other spell reviewer approved the alternative and, IF applicable, its cooling-period waiver in a reply to that comment
     * [ ] Record the passing selected release or passing explicitly approved alternative as the required release
       ```text
       Required release: vMAJOR.MINOR.PATCH
@@ -77,7 +78,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * [ ] Stop Foundry setup
       * [ ] Record the failed command and complete output in the spell PR
       * [ ] Diagnose and resolve the failure
-      * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`; the failure does not authorize another automatic installation
+      * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`
       * [ ] Rerun the exact failed command
         ```text
         _Insert the complete command output here_
@@ -475,7 +476,9 @@ _Insert your local test logs here_
 ## Deployed Stage
 
 * Crafter's comment in the PR
-  * [ ] Contains the exact pre-deployment `make verify-foundry release=vMAJOR.MINOR.PATCH` command, including `ignore-age=1` when `FOUNDRY_IGNORE_AGE` is `"1"` in CI
+  * [ ] Contains the exact Foundry verification command run before deployment
+  * [ ] The command's `release=vMAJOR.MINOR.PATCH` argument matches `FOUNDRY_RELEASE` in CI
+  * [ ] The command includes `ignore-age=1` if and only if `FOUNDRY_IGNORE_AGE` is `"1"` in CI
   * [ ] Contains the complete verifier output
   * [ ] Shows that the verifier exited `0`
   * [ ] Shows that the desired and installed releases match the release pinned in CI
@@ -526,7 +529,6 @@ _Insert your local test logs here_
   * [ ] Ensure that any other env variable does not affect execution of the tests (for example, by inspecting the output of `printenv | grep "FOUNDRY_\|DAPP_"`)
   * [ ] Check all tests are passing locally using `make test`
 * [ ] Publish an explicit "good to handover" comment confirming the crafter's deployment information
-* [ ] Confirm that both official reviewers published explicit "good to handover" comments
 
 ```
 _Insert your local test logs here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -9,6 +9,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```bash
     gh pr checkout PR_NUMBER
     ```
+* Review Foundry setup changes before execution
+  * IF the spell PR changes `Makefile` or any repository-controlled file loaded or executed by a Foundry setup target, including files under `scripts/setup-foundry/`
+    * [ ] Confirm that the spell PR documents the purpose of the changes
+    * [ ] Inspect the complete diff for those changes before running any Foundry setup command
+    * IF the purpose is undocumented or any concern remains unresolved
+      * [ ] Stop Foundry setup
+      * [ ] Notify the spell team
 * Verify and install the Foundry toolkit
   * Phase 1 — Mandatory release acceptance
     * [ ] Run `make select-foundry`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -64,7 +64,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Repeat the exact release review above for the alternative
   * IF an alternative release is selected
     * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
-    * [ ] Obtain explicit spell-team approval in a reply to that comment or another spell PR comment
+    * [ ] Both spell reviewers reply to that comment with explicit approval
   * [ ] Confirm that the selected release has an `Acceptable` review outcome
   * [ ] Compare the selected release with the current CI Foundry release
   * [ ] IF the selected release differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
@@ -462,11 +462,6 @@ _Insert your local test logs here_
   * [ ] Ensure newly added code is covered by tests
   * [ ] Check if chainlog needs to be updated
   * [ ] Copy over and redo "Tests" section from the above
-* Crafter's pre-deployment Foundry evidence in the spell PR
-  * [ ] Contains the exact `make verify-foundry release=vMAJOR.MINOR.PATCH` command, including `ignore-age=1` when it is present in CI
-  * [ ] Contains the complete verifier output
-  * [ ] Shows that the verifier exited `0`
-  * [ ] Shows that the desired and installed releases match the release pinned in CI
 * Independently verify the CI-pinned Foundry release
   * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when it is present in CI
     ```text
@@ -479,6 +474,10 @@ _Insert your local test logs here_
 ## Deployed Stage
 
 * Crafter's comment in the PR
+  * [ ] Contains the exact pre-deployment `make verify-foundry release=vMAJOR.MINOR.PATCH` command, including `ignore-age=1` when it is present in CI
+  * [ ] Contains the complete verifier output
+  * [ ] Shows that the verifier exited `0`
+  * [ ] Shows that the desired and installed releases match the release pinned in CI
   * [ ] Contains a URL to the deployed spell
     * [ ] URL matches the spell address declared in `config.sol`
   * [ ] Contains a URL to the Tenderly Testnet
@@ -525,7 +524,8 @@ _Insert your local test logs here_
     _Insert most recent commit hash where CI was passing_
   * [ ] Ensure that any other env variable does not affect execution of the tests (for example, by inspecting the output of `printenv | grep "FOUNDRY_\|DAPP_"`)
   * [ ] Check all tests are passing locally using `make test`
-* [ ] Publish an explicit "good to handover" comment
+* [ ] Reply to the crafter's deployment-information comment with an explicit "good to handover" approval
+* [ ] Confirm that the deployment-information comment has explicit "good to handover" approval replies from both official reviewers
 
 ```
 _Insert your local test logs here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -31,9 +31,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       _Insert the complete selector output here_
       ```
     * [ ] Treat the selected release as the release under review
-    * [ ] Review every published Foundry [security advisory](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
-      * [ ] IF no advisories are published, strike through this item and remove the evidence block below
-      * OTHERWISE, for each advisory
+    * IF there are any published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
+      * For each advisory
         * [ ] Compare its affected version range with the release under review
         * [ ] IF the release is affected or applicability is unclear, review every linked official upstream source
         * [ ] Record the evidence below

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -33,7 +33,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       Release notes: _Insert exact release URL_
       Compatibility: Compatible / Incompatible — _Insert rationale_
       ```
-    * IF the release under review is affected, its applicability is unclear, or it is incompatible
+    * IF the release under review does not pass the security review or applicable compatibility check
       * [ ] Stop Foundry setup and notify the spell team
       * Repeat until the release under review is unaffected and, when compatibility is checked, compatible
         * [ ] Select an exact alternative supported by an official upstream reference

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -14,89 +14,53 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete selector output here_
     ```
-  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the selector release
   * [ ] Record the workflow-level Foundry settings from the checked-out spell PR's `.github/workflows/tests.yaml` ([upstream file](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml))
     ```text
     FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
     FOUNDRY_IGNORE_AGE: 0 / 1
     ```
-  * Review the selector release and each alternative candidate release selected below
-    * Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories)
-      * [ ] Confirm that no affected version range includes the release
-        ```text
-        Security advisory URL: None / _Insert exact URL_
-        Release affected: Yes / No
-        Reason: _Insert why or why not the release is affected_
-        ```
-      * [ ] IF a security advisory links to a supplemental official advisory or incident notice, read it and determine its applicability and remediation
-        ```text
-        Linked official notices: None / _Insert URLs and applicability or remediation outcomes_
-        ```
-    * IF the candidate differs from `FOUNDRY_RELEASE` on the spell PR's base branch, review it as a CI release update
-      * Confirm from the release's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
-        * [ ] The release is not a draft
-        * [ ] The release is not a prerelease
-        * [ ] The release is marked immutable
-        ```text
-        Release metadata URL: _Insert exact release URL_
-        Draft: Yes / No
-        Prerelease: Yes / No
-        Immutable: Yes / No
-        ```
-      * Read the release's complete Foundry [release notes](https://github.com/foundry-rs/foundry/releases)
-        * [ ] Identify every breaking change
-          ```text
-          Release notes: _Insert exact release URL_
-          Breaking changes: None / _Insert breaking changes_
-          ```
-        * [ ] IF breaking changes exist, determine whether they are compatible with spell building, testing, and deployment
-          ```text
-          Compatibility outcome: Compatible / Incompatible
-          ```
-    * [ ] Record whether the release is acceptable
-      ```text
-      Candidate release: vMAJOR.MINOR.PATCH
-      Outcome: Acceptable / Affected / Applicability unclear / Incompatible
-      ```
-  * IF the candidate is not acceptable
-    * [ ] Notify the spell team
-    * [ ] Identify an exact alternative release, either older or newer
-    * [ ] Locate an official upstream reference showing that the alternative is unaffected or addresses the issue
-    * [ ] Repeat the exact release review above for the alternative
-  * IF an alternative release is selected
-    * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
-    * [ ] Both spell reviewers reply to that comment with explicit approval
-  * [ ] Record the selector release as the required release, or the explicitly approved alternative when one was selected
-  * [ ] Confirm that the required release has an `Acceptable` review outcome
+  * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the selector release
+    ```text
+    Security review: Unaffected / Affected / Applicability unclear
+    Sources and rationale: None affecting the release / _Insert URLs and outcome_
+    ```
+  * [ ] IF the spell PR changes `FOUNDRY_RELEASE`, read the CI-pinned release's complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
+    ```text
+    Release notes: _Insert exact release URL_
+    Compatibility: Compatible / Incompatible — _Insert rationale_
+    ```
+  * IF the selector release is affected, its applicability is unclear, or it is incompatible
+    * [ ] Stop Foundry setup and notify the spell team
+    * [ ] Select an exact alternative supported by an official upstream reference
+    * [ ] Repeat the advisory and applicable release-note checks for the alternative
+    * [ ] Confirm that the spell PR identifies the alternative and its upstream reference
+    * [ ] Confirm that both spell reviewers explicitly approved the alternative
+  * [ ] Record the selector release as the required release, or the explicitly approved alternative
+    ```text
+    Required release: vMAJOR.MINOR.PATCH
+    ```
   * [ ] IF the required release is less than 14 days old, confirm that the spell PR contains an explicit cooling-period waiver
-  * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release
-  * [ ] Confirm that `FOUNDRY_IGNORE_AGE` is `"1"` when the cooling period is waived and `"0"` otherwise
-  * [ ] IF the spell PR changes `FOUNDRY_RELEASE`, confirm that the change matches the required release
-  * [ ] IF the spell PR changes `FOUNDRY_IGNORE_AGE`, confirm that the change matches the cooling-period policy
-  * [ ] Confirm that `make install-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
-  * [ ] Confirm that `make verify-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
+  * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release and `FOUNDRY_IGNORE_AGE` is `"1"` when the cooling period is waived or `"0"` otherwise
+  * [ ] IF the Foundry workflow changes, confirm that `make install-foundry` and `make verify-foundry` use both CI settings
   * [ ] IF the required release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
     ```text
     _Insert the complete verifier output here_
     ```
-  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the required release
-  * [ ] OTHERWISE IF the exact-release verifier fails with `Required action: install`, confirm that it reports:
-    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the required release
-    * [ ] `Installation command:` matching the required release and including `ignore-age=1` when the cooling period is waived
+  * IF the verifier exits nonzero with `Required action: install`, the required release, and a matching `Installation command`
     * [ ] Run the exact `Installation command` printed by the verifier
       ```text
       _Insert the complete installer output here_
       ```
     * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-    * [ ] IF the installer exits `0`, rerun the same exact-release verifier
+    * [ ] Rerun the same exact-release verifier
       ```text
       _Insert the complete verifier output here_
       ```
-      * [ ] Confirm that the verifier exits `0`
-  * [ ] IF `make select-foundry` or `make install-foundry` exits nonzero, or `make verify-foundry` exits nonzero without the expected `Required action: install`, desired release, and installation command, record the failed command and complete output in the spell PR
-    * [ ] Stop Foundry setup
-    * [ ] Diagnose the failure
-    * [ ] Resolve the failure
+  * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
+  * IF any Foundry setup command exits nonzero other than the expected install response above
+    * Stop Foundry setup
+    * [ ] Record the failed command and complete output in the spell PR
+    * [ ] Diagnose and resolve the failure
     * [ ] Rerun the exact failed command
       ```text
       _Insert the complete command output here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -15,7 +15,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```text
       _Insert the complete selector output here_
       ```
-    * [ ] Record the workflow-level Foundry settings from the checked-out spell PR's [`.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
+    * [ ] Copy the workflow-level Foundry settings from the checked-out spell PR's `.github/workflows/tests.yaml` into the block below
       ```text
       FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
       FOUNDRY_IGNORE_AGE: 0 / 1
@@ -39,7 +39,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         * [ ] Repeat the security and applicable compatibility checks above
       * [ ] Confirm that the spell PR identifies the alternative and its upstream reference
       * [ ] Confirm that both spell reviewers explicitly approved the alternative
-    * [ ] Record the passing selected release, or the passing explicitly approved alternative, as the required release
+    * [ ] Record the passing selected release or passing explicitly approved alternative as the required release
       ```text
       Required release: vMAJOR.MINOR.PATCH
       ```
@@ -51,7 +51,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * IF the spell PR changes `FOUNDRY_RELEASE`
       * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release
       * [ ] Confirm that `FOUNDRY_IGNORE_AGE` is `"1"` only for an approved cooling-period waiver or `"0"` otherwise
-      * [ ] Confirm that `make install-foundry` and `make verify-foundry` use both CI settings
+      * [ ] Confirm that the `Install Foundry` step in `.github/workflows/tests.yaml` runs `make install-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
+      * [ ] Confirm that the `Verify Foundry` step in `.github/workflows/tests.yaml` runs `make verify-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
   * Phase 3 — Mandatory developer installation and verification
     * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
       ```text
@@ -63,8 +64,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       _Insert the complete verifier output here_
       ```
     * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
-  * Phase 4 — Conditional failure handling
-    * IF any Foundry setup command in Phases 1–3 exits nonzero, apply this recovery branch immediately
+  * Failure handling — applies throughout Phases 1–3
+    * IF any Foundry setup command above exits nonzero, apply this recovery branch immediately
       * [ ] Stop Foundry setup
       * [ ] Record the failed command and complete output in the spell PR
       * [ ] Diagnose and resolve the failure

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -21,10 +21,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       FOUNDRY_IGNORE_AGE: 0 / 1
       ```
     * [ ] Treat the selected release as the release under review
-    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the release under review
+    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for an affected version range that includes the release under review
+    * [ ] IF an applicable advisory links an official Foundry incident notice, review that notice for unresolved issues affecting the release
       ```text
       Security review: Unaffected / Affected / Applicability unclear
-      Sources and rationale: None affecting the release / _Insert URLs and outcome_
+      Security advisories: _Insert URLs and outcome_
+      Linked incident notices: None / _Insert URLs and outcome_
       ```
     * [ ] IF the spell PR changes `FOUNDRY_RELEASE`, read the release under review's complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
       ```text

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -53,7 +53,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * Phase 2 — Conditional CI synchronization
     * IF the spell PR changes `FOUNDRY_RELEASE`
       * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release
-      * [ ] Confirm that `FOUNDRY_IGNORE_AGE` is `"1"` only for an approved cooling-period waiver or `"0"` otherwise
+      * [ ] IF a cooling-period waiver was approved, confirm that `FOUNDRY_IGNORE_AGE` is `"1"`; OTHERWISE confirm that it is `"0"`
       * [ ] Confirm that the `Install Foundry` step in `.github/workflows/tests.yaml` runs `make install-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
       * [ ] Confirm that the `Verify Foundry` step in `.github/workflows/tests.yaml` runs `make verify-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
   * Phase 3 — Mandatory developer installation and verification

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -57,12 +57,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * [ ] Confirm that the `Install Foundry` step in `.github/workflows/tests.yaml` runs `make install-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
       * [ ] Confirm that the `Verify Foundry` step in `.github/workflows/tests.yaml` runs `make verify-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
   * Phase 3 — Mandatory developer installation and verification
-    * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
+    * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; IF the required release is less than 14 days old and its cooling-period waiver was approved, include `ignore-age=1`
       ```text
       _Insert the complete installer output here_
       ```
     * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-    * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
+    * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`; IF the required release is less than 14 days old and its cooling-period waiver was approved, include `ignore-age=1`
       ```text
       _Insert the complete verifier output here_
       ```

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -31,15 +31,17 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       _Insert the complete selector output here_
       ```
     * [ ] Treat the selected release as the release under review
-    * Review every published Foundry [security advisory](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
-      * [ ] For each advisory, compare its affected version range with the release under review
-      * [ ] For each advisory that affects the release or whose applicability is unclear, review every linked official upstream advisory or incident notice for unresolved issues affecting the release
-      * [ ] Record one evidence entry per advisory; IF no advisories are published, record `None published`
-        ```text
-        Foundry advisory: None published / _Insert URL_
-        Affects release under review: N/A / Yes / No / Unclear — _Insert rationale_
-        Linked official sources: N/A / None / _Insert URLs and outcome_
-        ```
+    * [ ] Review every published Foundry [security advisory](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
+      * [ ] IF no advisories are published, strike through this item and remove the evidence block below
+      * OTHERWISE, for each advisory
+        * [ ] Compare its affected version range with the release under review
+        * [ ] IF the release is affected or applicability is unclear, review every linked official upstream source
+        * [ ] Record the evidence below
+          ```text
+          Foundry advisory: _Insert URL_
+          Affects release under review: Yes / No / Unclear — _Insert rationale_
+          Linked official sources: None / _Insert URLs and outcome_
+          ```
     * [ ] Copy the workflow-level Foundry settings from the checked-out spell PR's `.github/workflows/tests.yaml` into the block below
       ```text
       FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
@@ -57,8 +59,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         * [ ] Select an exact alternative supported by an official upstream reference
         * [ ] Treat the alternative as the release under review
         * [ ] Repeat the security and applicable compatibility checks above
-      * [ ] Confirm that the crafter's alternative-release comment identifies the passing alternative reviewed above, cites its supporting official upstream reference, and requests a cooling-period waiver IF AND ONLY IF the alternative is less than 14 days old
-      * [ ] IF the alternative is less than 14 days old, reply using `Approved alternative Foundry release: vMAJOR.MINOR.PATCH; cooling-period waiver: approved.`; OTHERWISE use `Approved alternative Foundry release: vMAJOR.MINOR.PATCH; cooling-period waiver: not required.`
+      * [ ] Review the crafter's alternative-release comment and confirm that it identifies the passing alternative reviewed above, cites its supporting official upstream reference, and requests a cooling-period waiver IF AND ONLY IF the alternative is less than 14 days old
+      * [ ] IF the comment does not match the passing alternative, upstream reference, or applicable cooling-period waiver requirement, stop approval and notify the spell team
+      * IF the comment matches
+        * [ ] IF the alternative is less than 14 days old, reply using `Approved alternative Foundry release: vMAJOR.MINOR.PATCH; cooling-period waiver: approved.`
+        * [ ] OTHERWISE, reply using `Approved alternative Foundry release: vMAJOR.MINOR.PATCH; cooling-period waiver: not required.`
       * [ ] Confirm that the other spell reviewer replied with equivalent approval naming the same release and waiver outcome
     * [ ] Record the passing selected release or passing explicitly approved alternative as the required release
       ```text
@@ -465,12 +470,12 @@ _Insert your local test logs here_
     FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
     FOUNDRY_IGNORE_AGE: 0 / 1
     ```
-  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=0/1` with those exact values, matching the `Verify Foundry` CI step
+  * [ ] Confirm that the `Verify Foundry` CI step passes `${FOUNDRY_RELEASE}` and `${FOUNDRY_IGNORE_AGE}` to `make verify-foundry`
+  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=0/1` locally with the exact workflow-level values recorded above
     ```text
     _Insert the complete verifier output here_
     ```
-  * [ ] Confirm that the verifier exits `0`
-  * [ ] Confirm that the desired and installed releases match the release pinned in CI
+  * [ ] Confirm that the verifier exits `0` and reports the recorded `FOUNDRY_RELEASE` as both the desired and installed release
 * [ ] Do a final review of the checklist comment before posting to ensure all checks are correct and complete
 * [ ] Verify that all checkboxes and strikethroughs display correctly in the rendered checklist comment before posting
 * [ ] IF all checks pass, make sure to include explicit "Good to deploy" comment

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -10,17 +10,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     gh pr checkout PR_NUMBER
     ```
 * Verify and Install Foundry toolkit
-  * [ ] Record the workflow-level Foundry settings from [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
-    ```text
-    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
-    FOUNDRY_IGNORE_AGE: 0 / 1
-    ```
   * [ ] Run `make select-foundry`
     ```text
     _Insert the complete selector output here_
     ```
-  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the desired release
-  * Review the desired release and each alternative candidate release selected below
+  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the selector release
+  * Review the selector release and each alternative candidate release selected below
     * Confirm from the release's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
       * [ ] The release is not a draft
       * [ ] The release is not a prerelease
@@ -65,21 +60,28 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * IF an alternative release is selected
     * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
     * [ ] Both spell reviewers reply to that comment with explicit approval
-  * [ ] Confirm that the selected release has an `Acceptable` review outcome
-  * [ ] Compare the selected release with the current `FOUNDRY_RELEASE`
-  * [ ] IF the selected release differs from the CI release, update `FOUNDRY_RELEASE` in [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
-  * [ ] IF the selected release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] IF the cooling-period waiver applies, set `FOUNDRY_IGNORE_AGE` to `"1"` in [`sky-ecosystem/spells-mainnet/.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml); OTHERWISE set it to `"0"`
+  * [ ] Record the selector release as the required release, or the explicitly approved alternative when one was selected
+  * [ ] Confirm that the required release has an `Acceptable` review outcome
+  * [ ] IF the required release is less than 14 days old, confirm that the spell PR contains an explicit cooling-period waiver
+  * [ ] Record the workflow-level Foundry settings from the checked-out spell PR's `.github/workflows/tests.yaml` ([upstream file](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml))
+    ```text
+    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+    FOUNDRY_IGNORE_AGE: 0 / 1
+    ```
+  * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release
+  * [ ] Confirm that `FOUNDRY_IGNORE_AGE` is `"1"` when the cooling period is waived and `"0"` otherwise
+  * [ ] IF the spell PR changes `FOUNDRY_RELEASE`, confirm that the change matches the required release
+  * [ ] IF the spell PR changes `FOUNDRY_IGNORE_AGE`, confirm that the change matches the cooling-period policy
   * [ ] Confirm that `make install-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
   * [ ] Confirm that `make verify-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
-  * [ ] IF the selected release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
+  * [ ] IF the required release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
     ```text
     _Insert the complete verifier output here_
     ```
-  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the selected release
+  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the required release
   * [ ] OTHERWISE IF the exact-release verifier fails with `Required action: install`, confirm that it reports:
-    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the selected release
-    * [ ] `Installation command:` matching the selected release and including `ignore-age=1` when the cooling period is waived
+    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the required release
+    * [ ] `Installation command:` matching the required release and including `ignore-age=1` when the cooling period is waived
     * [ ] Run the exact `Installation command` printed by the verifier
       ```text
       _Insert the complete installer output here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -504,8 +504,8 @@ _Insert your local test logs here_
     _Insert most recent commit hash where CI was passing_
   * [ ] Ensure that any other env variable does not affect execution of the tests (for example, by inspecting the output of `printenv | grep "FOUNDRY_\|DAPP_"`)
   * [ ] Check all tests are passing locally using `make test`
-* [ ] Reply to the crafter's deployment-information comment with an explicit "good to handover" approval
-* [ ] Confirm that the deployment-information comment has explicit "good to handover" approval replies from both official reviewers
+* [ ] Publish an explicit "good to handover" comment confirming the crafter's deployment information
+* [ ] Confirm that both official reviewers published explicit "good to handover" comments
 
 ```
 _Insert your local test logs here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -14,32 +14,38 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete selector output here_
     ```
-  * [ ] Record the workflow-level Foundry settings from the checked-out spell PR's `.github/workflows/tests.yaml` ([upstream file](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml))
+  * [ ] Record the workflow-level Foundry settings from the checked-out spell PR's [`.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
     ```text
     FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
     FOUNDRY_IGNORE_AGE: 0 / 1
     ```
-  * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the selector release
+  * Treat the selected release as the release under review
+  * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the release under review
     ```text
     Security review: Unaffected / Affected / Applicability unclear
     Sources and rationale: None affecting the release / _Insert URLs and outcome_
     ```
-  * [ ] IF the spell PR changes `FOUNDRY_RELEASE`, read the CI-pinned release's complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
+  * [ ] IF the spell PR changes `FOUNDRY_RELEASE`, read the release under review's complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
     ```text
     Release notes: _Insert exact release URL_
     Compatibility: Compatible / Incompatible — _Insert rationale_
     ```
-  * IF the selector release is affected, its applicability is unclear, or it is incompatible
+  * IF the release under review is affected, its applicability is unclear, or it is incompatible
     * [ ] Stop Foundry setup and notify the spell team
-    * [ ] Select an exact alternative supported by an official upstream reference
-    * [ ] Repeat the advisory and applicable release-note checks for the alternative
+    * Repeat until the release under review is unaffected and, when compatibility is checked, compatible
+      * [ ] Select an exact alternative supported by an official upstream reference
+      * [ ] Treat the alternative as the release under review
+      * [ ] Repeat the security and applicable compatibility checks above
     * [ ] Confirm that the spell PR identifies the alternative and its upstream reference
     * [ ] Confirm that both spell reviewers explicitly approved the alternative
-  * [ ] Record the selector release as the required release, or the explicitly approved alternative
+  * [ ] Record the passing selected release, or the passing explicitly approved alternative, as the required release
     ```text
     Required release: vMAJOR.MINOR.PATCH
     ```
-  * [ ] IF the required release is less than 14 days old, confirm that the spell PR contains an explicit cooling-period waiver
+  * IF the required release is less than 14 days old
+    * [ ] Confirm that the spell PR contains a comment requesting an explicit cooling-period waiver
+    * [ ] Approve the waiver in a follow-up comment
+    * [ ] Confirm that the other spell reviewer approved the waiver in a follow-up comment
   * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release and `FOUNDRY_IGNORE_AGE` is `"1"` when the cooling period is waived or `"0"` otherwise
   * [ ] IF the Foundry workflow changes, confirm that `make install-foundry` and `make verify-foundry` use both CI settings
   * [ ] IF the required release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
@@ -58,7 +64,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```
   * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
   * IF any Foundry setup command exits nonzero other than the expected install response above
-    * Stop Foundry setup
+    * [ ] Stop Foundry setup
     * [ ] Record the failed command and complete output in the spell PR
     * [ ] Diagnose and resolve the failure
     * [ ] Rerun the exact failed command

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -6,6 +6,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 * Prepare the `spells-mainnet` checkout
   * [ ] Checkout the spell PR from a trusted local copy of the [`sky-ecosystem/spells-mainnet` repository](https://github.com/sky-ecosystem/spells-mainnet)
+    ```bash
+    gh pr checkout PR_NUMBER
+    ```
 * Verify and Install Foundry toolkit
   * [ ] Record the exact Foundry release and optional age waiver used by both `make install-foundry` and `make verify-foundry` in `.github/workflows/tests.yaml`
     ```text
@@ -16,84 +19,77 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```text
     _Insert the complete selector output here_
     ```
-  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the first candidate release
-  * Review each exact candidate release
-    * Confirm from the candidate's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
+  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the desired release
+  * Review the desired release and each alternative candidate release selected below
+    * Confirm from the release's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
       * [ ] The release is not a draft
       * [ ] The release is not a prerelease
       * [ ] The release is marked immutable
       ```text
-      Release metadata: _Insert exact release URL and outcome_
+      Release metadata URL: _Insert exact release URL_
+      Draft: Yes / No
+      Prerelease: Yes / No
+      Immutable: Yes / No
       ```
-    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) to confirm that no affected version range includes the candidate
-      ```text
-      Security advisories: _Insert URL and outcome_
-      ```
-    * [ ] Read the candidate's complete [release notes](https://github.com/foundry-rs/foundry/releases) and identify every breaking change
-      ```text
-      Release notes: _Insert exact release URL_
-      Breaking changes: None / _Insert breaking changes_
-      ```
-    * [ ] Determine whether the breaking changes are compatible with spell building, testing, and deployment
-      ```text
-      Compatibility outcome: Compatible / Incompatible
-      ```
-    * [ ] IF a security advisory or the release notes link to a supplemental official advisory or incident notice, read it and determine its applicability and remediation
-      ```text
-      Linked official notices: None / _Insert URLs and applicability or remediation outcomes_
-      ```
-    * [ ] Record whether the candidate is acceptable
+    * Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories)
+      * [ ] Confirm that no affected version range includes the release
+        ```text
+        Security advisory URL: None / _Insert exact URL_
+        Release affected: Yes / No
+        Reason: _Insert why or why not the release is affected_
+        ```
+      * [ ] IF a security advisory links to a supplemental official advisory or incident notice, read it and determine its applicability and remediation
+        ```text
+        Linked official notices: None / _Insert URLs and applicability or remediation outcomes_
+        ```
+    * Read the release's complete Foundry [release notes](https://github.com/foundry-rs/foundry/releases)
+      * [ ] Identify every breaking change
+        ```text
+        Release notes: _Insert exact release URL_
+        Breaking changes: None / _Insert breaking changes_
+        ```
+      * [ ] IF breaking changes exist, determine whether they are compatible with spell building, testing, and deployment
+        ```text
+        Compatibility outcome: Compatible / Incompatible
+        ```
+    * [ ] Record whether the release is acceptable
       ```text
       Candidate release: vMAJOR.MINOR.PATCH
       Outcome: Acceptable / Affected / Applicability unclear / Incompatible
       ```
-  * IF the candidate is affected, its applicability is unclear, or it has an incompatible breaking change
+  * IF the candidate is not acceptable
     * [ ] Notify the spell team
     * [ ] Identify an exact alternative release, either older or newer
     * [ ] Locate an official upstream reference showing that the alternative is unaffected or addresses the issue
-    * [ ] Repeat the exact candidate-release review above for the alternative
+    * [ ] Repeat the exact release review above for the alternative
   * IF an alternative release is selected
     * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
     * [ ] Obtain explicit spell-team approval in a reply to that comment or another spell PR comment
-  * [ ] Confirm that the selected candidate has an `Acceptable` review outcome
-  * [ ] Compare the selected candidate with the current CI Foundry release
-  * [ ] IF the selected candidate differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
-  * [ ] IF the selected candidate is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in `.github/workflows/tests.yaml`
-  * [ ] IF no cooling-period waiver applies, remove `ignore-age=1` from both Foundry commands in `.github/workflows/tests.yaml`
+  * [ ] Confirm that the selected release has an `Acceptable` review outcome
+  * [ ] Compare the selected release with the current CI Foundry release
+  * [ ] IF the selected release differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
+  * [ ] IF the selected release is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
+  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in `.github/workflows/tests.yaml`; OTHERWISE remove `ignore-age=1`
   * [ ] Confirm that both CI commands use the same release and age-waiver arguments
-  * The CI release remains pinned until a later approved release replaces it
-  * [ ] IF the selected candidate is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
+  * [ ] IF the selected release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
     ```text
     _Insert the complete verifier output here_
     ```
-  * [ ] OTHERWISE IF the selected candidate is less than 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
-    ```text
-    _Insert the complete verifier output here_
-    ```
-  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the selected candidate
-  * OTHERWISE IF the exact-release verifier fails with `Required action: install` and reports:
-    * `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the selected candidate
-    * `Installation command:` matching the selected candidate and including `ignore-age=1` when the cooling period is waived
+  * [ ] IF the exact-release verifier exits `0`, confirm that the installed release matches the selected release
+  * [ ] OTHERWISE IF the exact-release verifier fails with `Required action: install`, confirm that it reports:
+    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH` matching the selected release
+    * [ ] `Installation command:` matching the selected release and including `ignore-age=1` when the cooling period is waived
     * [ ] Run the exact `Installation command` printed by the verifier
       ```text
       _Insert the complete installer output here_
       ```
     * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-    * IF the installer exits `0`
-      * [ ] Rerun the same exact-release verifier
-        ```text
-        _Insert the complete verifier output here_
-        ```
+    * [ ] IF the installer exits `0`, rerun the same exact-release verifier
+      ```text
+      _Insert the complete verifier output here_
+      ```
       * [ ] Confirm that the verifier exits `0`
-  * IF any unexpected Foundry setup failure occurs:
-    * A `make select-foundry` invocation exits nonzero or does not report `Desired Foundry release: vMAJOR.MINOR.PATCH`
-    * A `make verify-foundry` invocation exits nonzero without:
-      * `Required action: install`
-      * `Desired Foundry release: vMAJOR.MINOR.PATCH`
-      * `Installation command:` matching the desired release and including `ignore-age=1` when the cooling period is waived
-    * A `make install-foundry` invocation exits nonzero
-    * [ ] Record the failed command and complete output in the spell PR
+  * [ ] IF `make select-foundry` or `make install-foundry` exits nonzero, or `make verify-foundry` exits nonzero without the expected `Required action: install`, desired release, and installation command, record the failed command and complete output in the spell PR
     * [ ] Stop Foundry setup
     * [ ] Diagnose the failure
     * [ ] Resolve the failure

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -12,15 +12,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     CI Foundry release: vMAJOR.MINOR.PATCH
     CI age waiver: None / ignore-age=1
     ```
-  * [ ] Run `make verify-foundry`
+  * [ ] Run `make select-foundry`
     ```text
     _Insert the complete selector output here_
     ```
-  * IF the verifier exits nonzero, confirm that it reports:
-    * [ ] `Required action: install`
-    * [ ] `Desired Foundry release: vMAJOR.MINOR.PATCH`
-    * [ ] `Installation command: make install-foundry release=vMAJOR.MINOR.PATCH`
-  * [ ] Record the verifier's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the first candidate release
+  * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the first candidate release
   * Review each exact candidate release
     * Confirm from the candidate's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
       * [ ] The release is not a draft
@@ -90,7 +86,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         _Insert the complete verifier output here_
         ```
       * [ ] Confirm that the verifier exits `0`
-  * IF either unexpected Foundry setup failure occurs:
+  * IF any unexpected Foundry setup failure occurs:
+    * A `make select-foundry` invocation exits nonzero or does not report `Desired Foundry release: vMAJOR.MINOR.PATCH`
     * A `make verify-foundry` invocation exits nonzero without:
       * `Required action: install`
       * `Desired Foundry release: vMAJOR.MINOR.PATCH`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -35,7 +35,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```
     * IF the release under review does not pass the security review or applicable compatibility check
       * [ ] Stop Foundry setup and notify the spell team
-      * Repeat until the release under review is unaffected and, when compatibility is checked, compatible
+      * Repeat until the release under review passes the security review and any required compatibility check
         * [ ] Select an exact alternative supported by an official upstream reference
         * [ ] Treat the alternative as the release under review
         * [ ] Repeat the security and applicable compatibility checks above

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -15,17 +15,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _Insert the complete selector output here_
     ```
   * [ ] Record the selector's `Desired Foundry release: vMAJOR.MINOR.PATCH` as the selector release
+  * [ ] Record the workflow-level Foundry settings from the checked-out spell PR's `.github/workflows/tests.yaml` ([upstream file](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml))
+    ```text
+    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+    FOUNDRY_IGNORE_AGE: 0 / 1
+    ```
   * Review the selector release and each alternative candidate release selected below
-    * Confirm from the release's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
-      * [ ] The release is not a draft
-      * [ ] The release is not a prerelease
-      * [ ] The release is marked immutable
-      ```text
-      Release metadata URL: _Insert exact release URL_
-      Draft: Yes / No
-      Prerelease: Yes / No
-      Immutable: Yes / No
-      ```
     * Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories)
       * [ ] Confirm that no affected version range includes the release
         ```text
@@ -37,16 +32,27 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         ```text
         Linked official notices: None / _Insert URLs and applicability or remediation outcomes_
         ```
-    * Read the release's complete Foundry [release notes](https://github.com/foundry-rs/foundry/releases)
-      * [ ] Identify every breaking change
+    * IF the candidate differs from `FOUNDRY_RELEASE` on the spell PR's base branch, review it as a CI release update
+      * Confirm from the release's exact Foundry [release metadata](https://github.com/foundry-rs/foundry/releases):
+        * [ ] The release is not a draft
+        * [ ] The release is not a prerelease
+        * [ ] The release is marked immutable
         ```text
-        Release notes: _Insert exact release URL_
-        Breaking changes: None / _Insert breaking changes_
+        Release metadata URL: _Insert exact release URL_
+        Draft: Yes / No
+        Prerelease: Yes / No
+        Immutable: Yes / No
         ```
-      * [ ] IF breaking changes exist, determine whether they are compatible with spell building, testing, and deployment
-        ```text
-        Compatibility outcome: Compatible / Incompatible
-        ```
+      * Read the release's complete Foundry [release notes](https://github.com/foundry-rs/foundry/releases)
+        * [ ] Identify every breaking change
+          ```text
+          Release notes: _Insert exact release URL_
+          Breaking changes: None / _Insert breaking changes_
+          ```
+        * [ ] IF breaking changes exist, determine whether they are compatible with spell building, testing, and deployment
+          ```text
+          Compatibility outcome: Compatible / Incompatible
+          ```
     * [ ] Record whether the release is acceptable
       ```text
       Candidate release: vMAJOR.MINOR.PATCH
@@ -63,11 +69,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Record the selector release as the required release, or the explicitly approved alternative when one was selected
   * [ ] Confirm that the required release has an `Acceptable` review outcome
   * [ ] IF the required release is less than 14 days old, confirm that the spell PR contains an explicit cooling-period waiver
-  * [ ] Record the workflow-level Foundry settings from the checked-out spell PR's `.github/workflows/tests.yaml` ([upstream file](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml))
-    ```text
-    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
-    FOUNDRY_IGNORE_AGE: 0 / 1
-    ```
   * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release
   * [ ] Confirm that `FOUNDRY_IGNORE_AGE` is `"1"` when the cooling period is waived and `"0"` otherwise
   * [ ] IF the spell PR changes `FOUNDRY_RELEASE`, confirm that the change matches the required release

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -19,7 +19,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
     FOUNDRY_IGNORE_AGE: 0 / 1
     ```
-  * Treat the selected release as the release under review
+  * [ ] Treat the selected release as the release under review
   * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the release under review
     ```text
     Security review: Unaffected / Affected / Applicability unclear

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -9,7 +9,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```bash
     gh pr checkout PR_NUMBER
     ```
-* Verify and Install Foundry toolkit
+* Verify and install the Foundry toolkit
+  * **Phase 1 — Mandatory release acceptance**
   * [ ] Run `make select-foundry`
     ```text
     _Insert the complete selector output here_
@@ -46,27 +47,28 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Confirm that the spell PR contains a comment requesting an explicit cooling-period waiver
     * [ ] Approve the waiver in a follow-up comment
     * [ ] Confirm that the other spell reviewer approved the waiver in a follow-up comment
-  * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release and `FOUNDRY_IGNORE_AGE` is `"1"` when the cooling period is waived or `"0"` otherwise
-  * [ ] IF the Foundry workflow changes, confirm that `make install-foundry` and `make verify-foundry` use both CI settings
-  * [ ] IF the required release is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`; OTHERWISE run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=1`
+  * **Phase 2 — Conditional CI synchronization**
+  * IF the spell PR changes `FOUNDRY_RELEASE`
+    * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release
+    * [ ] Confirm that `FOUNDRY_IGNORE_AGE` is `"1"` only for an approved cooling-period waiver or `"0"` otherwise
+    * [ ] Confirm that `make install-foundry` and `make verify-foundry` use both CI settings
+  * **Phase 3 — Mandatory developer installation and verification**
+  * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
+    ```text
+    _Insert the complete installer output here_
+    ```
+  * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
     ```text
     _Insert the complete verifier output here_
     ```
-  * IF the verifier exits nonzero with `Required action: install`, the required release, and a matching `Installation command`
-    * [ ] Run the exact `Installation command` printed by the verifier
-      ```text
-      _Insert the complete installer output here_
-      ```
-    * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-    * [ ] Rerun the same exact-release verifier
-      ```text
-      _Insert the complete verifier output here_
-      ```
   * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
-  * IF any Foundry setup command exits nonzero other than the expected install response above
+  * **Phase 4 — Conditional failure handling**
+  * IF any Foundry setup command in Phases 1–3 exits nonzero, apply this recovery branch immediately
     * [ ] Stop Foundry setup
     * [ ] Record the failed command and complete output in the spell PR
     * [ ] Diagnose and resolve the failure
+    * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`; the failure does not authorize another automatic installation
     * [ ] Rerun the exact failed command
       ```text
       _Insert the complete command output here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -10,70 +10,70 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     gh pr checkout PR_NUMBER
     ```
 * Verify and install the Foundry toolkit
-  * **Phase 1 — Mandatory release acceptance**
-  * [ ] Run `make select-foundry`
-    ```text
-    _Insert the complete selector output here_
-    ```
-  * [ ] Record the workflow-level Foundry settings from the checked-out spell PR's [`.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
-    ```text
-    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
-    FOUNDRY_IGNORE_AGE: 0 / 1
-    ```
-  * [ ] Treat the selected release as the release under review
-  * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the release under review
-    ```text
-    Security review: Unaffected / Affected / Applicability unclear
-    Sources and rationale: None affecting the release / _Insert URLs and outcome_
-    ```
-  * [ ] IF the spell PR changes `FOUNDRY_RELEASE`, read the release under review's complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
-    ```text
-    Release notes: _Insert exact release URL_
-    Compatibility: Compatible / Incompatible — _Insert rationale_
-    ```
-  * IF the release under review is affected, its applicability is unclear, or it is incompatible
-    * [ ] Stop Foundry setup and notify the spell team
-    * Repeat until the release under review is unaffected and, when compatibility is checked, compatible
-      * [ ] Select an exact alternative supported by an official upstream reference
-      * [ ] Treat the alternative as the release under review
-      * [ ] Repeat the security and applicable compatibility checks above
-    * [ ] Confirm that the spell PR identifies the alternative and its upstream reference
-    * [ ] Confirm that both spell reviewers explicitly approved the alternative
-  * [ ] Record the passing selected release, or the passing explicitly approved alternative, as the required release
-    ```text
-    Required release: vMAJOR.MINOR.PATCH
-    ```
-  * IF the required release is less than 14 days old
-    * [ ] Confirm that the spell PR contains a comment requesting an explicit cooling-period waiver
-    * [ ] Approve the waiver in a follow-up comment
-    * [ ] Confirm that the other spell reviewer approved the waiver in a follow-up comment
-  * **Phase 2 — Conditional CI synchronization**
-  * IF the spell PR changes `FOUNDRY_RELEASE`
-    * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release
-    * [ ] Confirm that `FOUNDRY_IGNORE_AGE` is `"1"` only for an approved cooling-period waiver or `"0"` otherwise
-    * [ ] Confirm that `make install-foundry` and `make verify-foundry` use both CI settings
-  * **Phase 3 — Mandatory developer installation and verification**
-  * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
-    ```text
-    _Insert the complete installer output here_
-    ```
-  * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
-  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
-    ```text
-    _Insert the complete verifier output here_
-    ```
-  * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
-  * **Phase 4 — Conditional failure handling**
-  * IF any Foundry setup command in Phases 1–3 exits nonzero, apply this recovery branch immediately
-    * [ ] Stop Foundry setup
-    * [ ] Record the failed command and complete output in the spell PR
-    * [ ] Diagnose and resolve the failure
-    * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`; the failure does not authorize another automatic installation
-    * [ ] Rerun the exact failed command
+  * Phase 1 — Mandatory release acceptance
+    * [ ] Run `make select-foundry`
       ```text
-      _Insert the complete command output here_
+      _Insert the complete selector output here_
       ```
-    * [ ] IF the failure cannot be resolved, notify the spell team
+    * [ ] Record the workflow-level Foundry settings from the checked-out spell PR's [`.github/workflows/tests.yaml`](https://github.com/sky-ecosystem/spells-mainnet/blob/master/.github/workflows/tests.yaml)
+      ```text
+      FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+      FOUNDRY_IGNORE_AGE: 0 / 1
+      ```
+    * [ ] Treat the selected release as the release under review
+    * [ ] Check the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) and every linked official notice for the release under review
+      ```text
+      Security review: Unaffected / Affected / Applicability unclear
+      Sources and rationale: None affecting the release / _Insert URLs and outcome_
+      ```
+    * [ ] IF the spell PR changes `FOUNDRY_RELEASE`, read the release under review's complete [release notes](https://github.com/foundry-rs/foundry/releases) and confirm that no breaking change prevents spell building, testing, or deployment
+      ```text
+      Release notes: _Insert exact release URL_
+      Compatibility: Compatible / Incompatible — _Insert rationale_
+      ```
+    * IF the release under review is affected, its applicability is unclear, or it is incompatible
+      * [ ] Stop Foundry setup and notify the spell team
+      * Repeat until the release under review is unaffected and, when compatibility is checked, compatible
+        * [ ] Select an exact alternative supported by an official upstream reference
+        * [ ] Treat the alternative as the release under review
+        * [ ] Repeat the security and applicable compatibility checks above
+      * [ ] Confirm that the spell PR identifies the alternative and its upstream reference
+      * [ ] Confirm that both spell reviewers explicitly approved the alternative
+    * [ ] Record the passing selected release, or the passing explicitly approved alternative, as the required release
+      ```text
+      Required release: vMAJOR.MINOR.PATCH
+      ```
+    * IF the required release is less than 14 days old
+      * [ ] Confirm that the spell PR contains a comment requesting an explicit cooling-period waiver
+      * [ ] Approve the waiver in a follow-up comment
+      * [ ] Confirm that the other spell reviewer approved the waiver in a follow-up comment
+  * Phase 2 — Conditional CI synchronization
+    * IF the spell PR changes `FOUNDRY_RELEASE`
+      * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release
+      * [ ] Confirm that `FOUNDRY_IGNORE_AGE` is `"1"` only for an approved cooling-period waiver or `"0"` otherwise
+      * [ ] Confirm that `make install-foundry` and `make verify-foundry` use both CI settings
+  * Phase 3 — Mandatory developer installation and verification
+    * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
+      ```text
+      _Insert the complete installer output here_
+      ```
+    * [ ] IF the installer reports `Required action: update-path`, apply the printed `PATH` instructions
+    * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`; include `ignore-age=1` only for an approved required release that is less than 14 days old
+      ```text
+      _Insert the complete verifier output here_
+      ```
+    * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
+  * Phase 4 — Conditional failure handling
+    * IF any Foundry setup command in Phases 1–3 exits nonzero, apply this recovery branch immediately
+      * [ ] Stop Foundry setup
+      * [ ] Record the failed command and complete output in the spell PR
+      * [ ] Diagnose and resolve the failure
+      * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`; the failure does not authorize another automatic installation
+      * [ ] Rerun the exact failed command
+        ```text
+        _Insert the complete command output here_
+        ```
+      * [ ] IF the failure cannot be resolved, notify the spell team
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -68,12 +68,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```text
       Required release: vMAJOR.MINOR.PATCH
       ```
-  * Phase 2 — Conditional CI synchronization
-    * IF the spell PR changes `FOUNDRY_RELEASE`
-      * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release
-      * [ ] IF a cooling-period waiver was approved, confirm that `FOUNDRY_IGNORE_AGE` is `"1"`; OTHERWISE confirm that it is `"0"`
-      * [ ] Confirm that the `Install Foundry` step in `.github/workflows/tests.yaml` runs `make install-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
-      * [ ] Confirm that the `Verify Foundry` step in `.github/workflows/tests.yaml` runs `make verify-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
+  * Phase 2 — Independent CI synchronization review
+    * [ ] Confirm that `FOUNDRY_RELEASE` matches the required release
+    * [ ] IF a cooling-period waiver was approved, confirm that `FOUNDRY_IGNORE_AGE` is `"1"`
+    * [ ] OTHERWISE, confirm that `FOUNDRY_IGNORE_AGE` is `"0"`
+    * [ ] Confirm that the `Install Foundry` step in `.github/workflows/tests.yaml` runs `make install-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
+    * [ ] Confirm that the `Verify Foundry` step in `.github/workflows/tests.yaml` runs `make verify-foundry release="${FOUNDRY_RELEASE}" ignore-age="${FOUNDRY_IGNORE_AGE}"`
   * Phase 3 — Mandatory developer installation and verification
     * [ ] Run `make install-foundry release=vMAJOR.MINOR.PATCH`; IF the required release is less than 14 days old and its cooling-period waiver was approved, include `ignore-age=1`
       ```text

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -7,10 +7,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Prepare the `spells-mainnet` checkout
   * [ ] Checkout the spell PR from a trusted local copy of the [`sky-ecosystem/spells-mainnet` repository](https://github.com/sky-ecosystem/spells-mainnet)
 * Verify and Install Foundry toolkit
-  * [ ] Record the exact Foundry release and optional age waiver used by both `make install-foundry` and `make verify-foundry` in `.github/workflows/tests.yaml`
+  * [ ] Record the workflow-level Foundry settings from `.github/workflows/tests.yaml`
     ```text
-    CI Foundry release: vMAJOR.MINOR.PATCH
-    CI age waiver: None / ignore-age=1
+    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+    FOUNDRY_IGNORE_AGE: 0 / 1
     ```
   * [ ] Run `make select-foundry`
     ```text
@@ -56,13 +56,14 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Post a spell PR comment containing its exact version and upstream reference before publishing the completed checklist
     * [ ] Obtain explicit spell-team approval in a reply to that comment or another spell PR comment
   * [ ] Confirm that the selected candidate has an `Acceptable` review outcome
-  * [ ] Compare the selected candidate with the current CI Foundry release
-  * [ ] IF the selected candidate differs from the CI release, update both Foundry commands in `.github/workflows/tests.yaml` to use `release=vMAJOR.MINOR.PATCH`
+  * [ ] Compare the selected candidate with the current `FOUNDRY_RELEASE`
+  * [ ] IF the selected candidate differs from the CI release, update `FOUNDRY_RELEASE` in `.github/workflows/tests.yaml`
   * [ ] IF the selected candidate is less than 14 days old, obtain an explicit cooling-period waiver in the spell PR
-  * [ ] IF the cooling-period waiver applies, add `ignore-age=1` to both Foundry commands in `.github/workflows/tests.yaml`
-  * [ ] IF no cooling-period waiver applies, remove `ignore-age=1` from both Foundry commands in `.github/workflows/tests.yaml`
-  * [ ] Confirm that both CI commands use the same release and age-waiver arguments
-  * The CI release remains pinned until a later approved release replaces it
+  * [ ] IF the cooling-period waiver applies, set `FOUNDRY_IGNORE_AGE` to `"1"` in `.github/workflows/tests.yaml`
+  * [ ] IF no cooling-period waiver applies, set `FOUNDRY_IGNORE_AGE` to `"0"` in `.github/workflows/tests.yaml`
+  * [ ] Confirm that `make install-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
+  * [ ] Confirm that `make verify-foundry` uses `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`
+  * The CI release and age-waiver setting remain pinned until a later approved change replaces them
   * [ ] IF the selected candidate is at least 14 days old, run `make verify-foundry release=vMAJOR.MINOR.PATCH`
     ```text
     _Insert the complete verifier output here_
@@ -467,12 +468,12 @@ _Insert your local test logs here_
   * [ ] Check if chainlog needs to be updated
   * [ ] Copy over and redo "Tests" section from the above
 * Crafter's pre-deployment Foundry evidence in the spell PR
-  * [ ] Contains the exact `make verify-foundry release=vMAJOR.MINOR.PATCH` command, including `ignore-age=1` when it is present in CI
+  * [ ] Contains the exact `make verify-foundry release=vMAJOR.MINOR.PATCH` command, including `ignore-age=1` when `FOUNDRY_IGNORE_AGE` is `"1"` in CI
   * [ ] Contains the complete verifier output
   * [ ] Shows that the verifier exited `0`
   * [ ] Shows that the desired and installed releases match the release pinned in CI
 * Independently verify the CI-pinned Foundry release
-  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when it is present in CI
+  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when `FOUNDRY_IGNORE_AGE` is `"1"` in CI
     ```text
     _Insert the complete verifier output here_
     ```

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -11,24 +11,34 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     ```
 * Confirm that Foundry setup changes are handled separately
   * IF the spell PR changes `Makefile` or any repository-controlled file loaded or executed by a Foundry setup target, including files under `scripts/setup-foundry/`
-    * [ ] Stop Foundry setup
     * [ ] Ask the spell team to move the Foundry setup changes to a separate maintenance PR
     * [ ] Resume only after the maintenance PR is merged and the spell PR is updated
 * Verify and install the Foundry toolkit
+  * Failure handling — applies throughout Phases 1–3
+    * IF any Foundry setup command below exits nonzero, apply this recovery branch immediately
+      * [ ] Stop Foundry setup
+      * [ ] Record the failed command and complete output in the spell PR
+      * [ ] Diagnose and resolve the failure
+      * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`
+      * [ ] Rerun the exact failed command
+        ```text
+        _Insert the complete command output here_
+        ```
+      * [ ] IF the failure cannot be resolved, notify the spell team
   * Phase 1 — Mandatory release acceptance
     * [ ] Run `make select-foundry`
       ```text
       _Insert the complete selector output here_
       ```
     * [ ] Treat the selected release as the release under review
-    * Review the published Foundry [security advisories](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
-      * [ ] Read each potentially applicable advisory and determine whether its affected version range includes the release
-      * [ ] Review every official upstream advisory or incident notice linked from an applicable advisory for unresolved issues affecting the release
-      * [ ] Record the security review evidence
+    * Review every published Foundry [security advisory](https://github.com/foundry-rs/foundry/security/advisories) for the release under review
+      * [ ] For each advisory, compare its affected version range with the release under review
+      * [ ] For each advisory that affects the release or whose applicability is unclear, review every linked official upstream advisory or incident notice for unresolved issues affecting the release
+      * [ ] Record one evidence entry per advisory; IF no advisories are published, record `None published`
         ```text
-        Security review: Unaffected / Affected / Applicability unclear
-        Security advisories: None affecting the release / _Insert URLs and outcome_
-        Linked official sources: None / _Insert URLs and outcome_
+        Foundry advisory: None published / _Insert URL_
+        Affects release under review: N/A / Yes / No / Unclear — _Insert rationale_
+        Linked official sources: N/A / None / _Insert URLs and outcome_
         ```
     * [ ] Copy the workflow-level Foundry settings from the checked-out spell PR's `.github/workflows/tests.yaml` into the block below
       ```text
@@ -47,11 +57,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
         * [ ] Select an exact alternative supported by an official upstream reference
         * [ ] Treat the alternative as the release under review
         * [ ] Repeat the security and applicable compatibility checks above
-      * Crafter's alternative-release comment
-        * [ ] Contains the exact alternative release to install and its upstream reference
-        * [ ] IF the alternative is less than 14 days old, contains an explicit cooling-period waiver request
-      * [ ] Approve the alternative and, IF applicable, its cooling-period waiver in a reply to that comment
-      * [ ] Confirm that the other spell reviewer approved the alternative and, IF applicable, its cooling-period waiver in a reply to that comment
+      * [ ] Confirm that the crafter's alternative-release comment identifies the passing alternative reviewed above, cites its supporting official upstream reference, and requests a cooling-period waiver IF AND ONLY IF the alternative is less than 14 days old
+      * [ ] IF the alternative is less than 14 days old, reply using `Approved alternative Foundry release: vMAJOR.MINOR.PATCH; cooling-period waiver: approved.`; OTHERWISE use `Approved alternative Foundry release: vMAJOR.MINOR.PATCH; cooling-period waiver: not required.`
+      * [ ] Confirm that the other spell reviewer replied with equivalent approval naming the same release and waiver outcome
     * [ ] Record the passing selected release or passing explicitly approved alternative as the required release
       ```text
       Required release: vMAJOR.MINOR.PATCH
@@ -73,17 +81,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       _Insert the complete verifier output here_
       ```
     * [ ] Confirm that the final verifier exits `0` and reports the required release as both desired and installed
-  * Failure handling — applies throughout Phases 1–3
-    * IF any Foundry setup command above exits nonzero, apply this recovery branch immediately
-      * [ ] Stop Foundry setup
-      * [ ] Record the failed command and complete output in the spell PR
-      * [ ] Diagnose and resolve the failure
-      * [ ] IF verification fails after a successful mandatory installation, diagnose the verifier failure, including `PATH`
-      * [ ] Rerun the exact failed command
-        ```text
-        _Insert the complete command output here_
-        ```
-      * [ ] IF the failure cannot be resolved, notify the spell team
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_
@@ -463,7 +460,12 @@ _Insert your local test logs here_
   * [ ] Check if chainlog needs to be updated
   * [ ] Copy over and redo "Tests" section from the above
 * Independently verify the CI-pinned Foundry release
-  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH`, including `ignore-age=1` when `FOUNDRY_IGNORE_AGE` is `"1"` in CI
+  * [ ] Copy the current workflow-level Foundry settings from the local `.github/workflows/tests.yaml`
+    ```text
+    FOUNDRY_RELEASE: vMAJOR.MINOR.PATCH
+    FOUNDRY_IGNORE_AGE: 0 / 1
+    ```
+  * [ ] Run `make verify-foundry release=vMAJOR.MINOR.PATCH ignore-age=0/1` with those exact values, matching the `Verify Foundry` CI step
     ```text
     _Insert the complete verifier output here_
     ```
@@ -478,7 +480,7 @@ _Insert your local test logs here_
 * Crafter's comment in the PR
   * [ ] Contains the exact Foundry verification command run before deployment
   * [ ] The command's `release=vMAJOR.MINOR.PATCH` argument matches `FOUNDRY_RELEASE` in CI
-  * [ ] The command includes `ignore-age=1` if and only if `FOUNDRY_IGNORE_AGE` is `"1"` in CI
+  * [ ] The command's `ignore-age=0/1` argument matches `FOUNDRY_IGNORE_AGE` in CI
   * [ ] Contains the complete verifier output
   * [ ] Shows that the verifier exited `0`
   * [ ] Shows that the desired and installed releases match the release pinned in CI

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -34,7 +34,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       Compatibility: Compatible / Incompatible — _Insert rationale_
       ```
     * IF the release under review does not pass the security review or applicable compatibility check
-      * [ ] Stop Foundry setup and notify the spell team
+      * [ ] Stop Foundry setup
+      * [ ] Notify the spell team that the release under review failed the security review or applicable compatibility check
       * Repeat until the release under review passes the security review and any required compatibility check
         * [ ] Select an exact alternative supported by an official upstream reference
         * [ ] Treat the alternative as the release under review


### PR DESCRIPTION
## Summary

Updates the Foundry tooling steps for spell crafters and reviewers to use one repository-owned release-selection, installation, and verification workflow while keeping both checklists aligned.

## Rationale

On `master`, both checklists instruct users to run `foundryup --install stable` and record the installed versions. They do not standardize release-age selection, verify the provenance of the installed binaries, or ensure that CI and local tooling use the same reviewed release and cooling-period waiver state.

The updated workflow uses the commands proposed in [spells-mainnet#560](https://github.com/sky-ecosystem/spells-mainnet/pull/560). `make select-foundry` selects the newest immutable stable release published at least 14 days ago whose supported archives publish SHA-256 digests and SLSA provenance attestations. The crafter and reviewers review and record the required release, the crafter synchronizes the workflow-level `FOUNDRY_RELEASE` and `FOUNDRY_IGNORE_AGE`, the reviewer independently confirms both values, and the exact required release is installed before the installed binaries are verified.

For an approved alternative release that is less than 14 days old, `ignore-age=1` waives only the cooling period; the release metadata and applicable artifact attestations remain mandatory.

## Changes

- Run `make select-foundry` and record the selector output.
- Review the security sources for the exact release under review.
- Record the required release and synchronize both workflow-level Foundry settings with the required release and waiver state.
- Install the exact required release before running `make verify-foundry`.
- Use `ignore-age=1` only after explicit approval to waive the 14-day cooling period.
- Keep the crafter and reviewer workflows aligned.
- Record the selector, installer, and final verifier outputs.

## Related

- Implement the shared Foundry setup commands and CI enforcement in [spells-mainnet#560](https://github.com/sky-ecosystem/spells-mainnet/pull/560).
