### PR TITLE
Update spell handover checklists to use forum
    thread

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -31,6 +31,7 @@ Fileable
 GSM
 Getter
 Goerli
+GovOps
 IAM
 IPFS
 Integrations

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -246,7 +246,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Communicate deployed address to governance
   * [ ] Write a message with Deployed Address in the [Sky Core Executive Vote Address Handover Thread](https://forum.skyeco.com/t/sky-core-executive-vote-address-handover-thread/27995)
   * [ ] Wait until both spell reviewers confirm the spell address in the thread
-  * [ ] Tag Responsible Governance Facilitator in the private GovOps Slack coordination thread with the address
+  * [ ] Tag Responsible Governance Facilitator in the private GovOps Slack coordination thread with the link to the handover message
   * [ ] Wait until Responsible Governance Facilitator confirms handover in the private GovOps Slack coordination thread
 * [ ] Fill the rest of the Spell Crafter-related boxes in the Exec Sheet
 * Pre-Merge target branch pull attack checks

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -245,7 +245,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * [ ] Wait for at least two "good to handover" comments (containing local tests) from the official reviewers
 * Communicate deployed address to governance
   * [ ] Write a message with Deployed Address in the [Sky Core Executive Vote Address Handover Thread](https://forum.skyeco.com/t/sky-core-executive-vote-address-handover-thread/27995)
-  * [ ] Wait until both spell reviewers confirm the spell address in the thread
+  * [ ] Wait until both spell reviewers confirm the spell address in the Handover Thread
   * [ ] Tag Responsible Governance Facilitator in the private GovOps Slack coordination thread with the link to the handover message
   * [ ] Wait until Responsible Governance Facilitator confirms handover in the private GovOps Slack coordination thread
 * [ ] Fill the rest of the Spell Crafter-related boxes in the Exec Sheet

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -245,9 +245,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * [ ] Wait for at least two "good to handover" comments (containing local tests) from the official reviewers
 * Communicate deployed address to governance
   * [ ] Write a message with Deployed Address in the [Sky Core Executive Vote Address Handover Thread](https://forum.skyeco.com/t/sky-core-executive-vote-address-handover-thread/27995)
-  * [ ] Wait until both spell reviewers confirm the spell address in the Handover Thread
+  * [ ] Wait until both spell reviewers confirm the spell address in the Handover Thread
+
   * [ ] Tag Responsible Governance Facilitator in the private GovOps Slack coordination thread with the link to the handover message
-  * [ ] Wait until Responsible Governance Facilitator confirms handover in the private GovOps Slack coordination thread
+  * [ ] Wait until Responsible Governance Facilitator confirms handover in the Handover Thread
 * [ ] Fill the rest of the Spell Crafter-related boxes in the Exec Sheet
 * Pre-Merge target branch pull attack checks
   * IF within last THREE commits (or last 6 weeks) spells-mainnet repo contains a maintenance PR

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -246,7 +246,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Communicate deployed address to governance
   * [ ] Write a message with Deployed Address in the [Sky Core Executive Vote Address Handover Thread](https://forum.skyeco.com/t/sky-core-executive-vote-address-handover-thread/27995)
   * [ ] Wait until both spell reviewers confirm the spell address in the Handover Thread
-
   * [ ] Tag Responsible Governance Facilitator in the private GovOps Slack coordination thread with the link to the handover message
   * [ ] Wait until Responsible Governance Facilitator confirms handover in the Handover Thread
 * [ ] Fill the rest of the Spell Crafter-related boxes in the Exec Sheet

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -244,9 +244,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 * [ ] Wait for at least two "good to handover" comments (containing local tests) from the official reviewers
 * Communicate deployed address to governance
-  * [ ] Write a message with Deployed Address in [`new-spells` discord channel](https://discord.com/channels/893112320329396265/897483518316265553)
-  * [ ] Tag Responsible Governance Facilitator in the message with the address
-  * [ ] Wait until Responsible Governance Facilitator confirms handover in `new-spells`
+  * [ ] Write a message with Deployed Address in the [Sky Core Executive Vote Address Handover Thread](https://forum.skyeco.com/t/sky-core-executive-vote-address-handover-thread/27995)
+  * [ ] Wait until both spell reviewers confirm the spell address in the thread
+  * [ ] Tag Responsible Governance Facilitator in the private GovOps Slack coordination thread with the address
+  * [ ] Wait until Responsible Governance Facilitator confirms handover in the private GovOps Slack coordination thread
 * [ ] Fill the rest of the Spell Crafter-related boxes in the Exec Sheet
 * Pre-Merge target branch pull attack checks
   * IF within last THREE commits (or last 6 weeks) spells-mainnet repo contains a maintenance PR

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -436,7 +436,7 @@ _Insert your local test logs here_
 * [ ] Check that the spell address posted by the crafter in the [Sky Core Executive Vote Address Handover Thread](https://forum.skyeco.com/t/sky-core-executive-vote-address-handover-thread/27995) is correct
 * [ ] Confirm the address in the thread – via the forum "Reply" button on the post containing the current spell address, restating the address to make later edits detectable
   * Example: ``Confirming {YYYY-MM-DD} Core Spell at [`{SPELL_ADDRESS}`]({BLOCK_EXPLORER_URL}).``
-  * [ ] Wait until both spell reviewers confirm the spell address in the thread
-  * [ ] Wait until responsible governance facilitator confirms handover in the private GovOps Slack coordination thread
+  * [ ] Wait until both spell reviewers confirm the spell address in the Handover Thread
+  * [ ] Wait until Responsible Governance Facilitator confirms handover in the Handover Thread
 * [ ] Ensure that no changes were made to the code since the spell was deployed and archived
 * [ ] Approve spell PR for merge via 'Approve' review option

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -433,8 +433,10 @@ _Insert your local test logs here_
 
 ## Handover and Merge Stage
 
-* [ ] Check that the spell address posted by the crafter in [`new-spells`](https://discord.com/channels/893112320329396265/897483518316265553) is correct
-* [ ] Confirm the address in the [`new-spells`](https://discord.com/channels/893112320329396265/897483518316265553) channel (via a separate "reply to" message, restating the address to avoid edits)
-  * [ ] Wait until responsible governance facilitator confirms handover in `new-spells`
+* [ ] Check that the spell address posted by the crafter in the [Sky Core Executive Vote Address Handover Thread](https://forum.skyeco.com/t/sky-core-executive-vote-address-handover-thread/27995) is correct
+* [ ] Confirm the address in the thread – via the forum "Reply" button on the post containing the current spell address, restating the address to make later edits detectable
+  * Example: ``Confirming {YYYY-MM-DD} Core Spell at [`{SPELL_ADDRESS}`]({BLOCK_EXPLORER_URL}).``
+  * [ ] Wait until both spell reviewers confirm the spell address in the thread
+  * [ ] Wait until responsible governance facilitator confirms handover in the private GovOps Slack coordination thread
 * [ ] Ensure that no changes were made to the code since the spell was deployed and archived
 * [ ] Approve spell PR for merge via 'Approve' review option


### PR DESCRIPTION
## Summary
  - replace Discord `new-spells` handover steps with the Sky Forum address handover thread
  - require both spell reviewers to confirm the spell address in the forum thread
  - move Responsible Governance Facilitator tagging to the private GovOps Slack coordination thread after reviewer confirmations