### PR TITLE
Add SUBPROXY_METHODS transfer checks

### DIFF
--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -145,14 +145,14 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] IF `direct execution` is `yes`
       * [ ] The hash is checked via `require(XXX_SPELL.codehash == XXX_SPELL_HASH, "XXX_SPELL/wrong-codehash");` inside Core spell
       * [ ] The Prime Agent spell is executed via `ProxyLike(XXX_PROXY).exec(XXX_SPELL, abi.encodeWithSignature("execute()"));`
+  * IF `SUBPROXY_METHODS` transfers are present
+    * [ ] Each transfer is executed via `SubProxyLike(XXX_SUBPROXY).exec(SUBPROXY_METHODS, abi.encodeWithSelector(SubProxyMethodsLike.transfer.selector, TOKEN, RECIPIENT, AMOUNT_IN_WAD));`
 * Add specific tests in `DssSpell.t.sol` to have sufficient test coverage for every spell action
   * [ ] Test new collaterals
   * [ ] Test new ilk registry values
   * [ ] Test new ChainLog values
   * [ ] Test DAI/USDS/SKY/SPK streams and payments, lerps
   * [ ] Test the sum of all DAI/USDS/SKY/SPK payments matches the Exec Sheet
-  * IF `SUBPROXY_METHODS` transfers are present
-    * [ ] Test each transfer from `XXX_SUBPROXY` with a pre-cast token balance check and exact `XXX_SUBPROXY`/recipient balance deltas
 * Run tests via `make test` (or `make test match=<test_name>` to inspect debug traces)
   * [ ] Ensure good coverage (every spell action is tested)
   * [ ] Ensure every test function is declared as `public`

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -146,7 +146,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * [ ] The hash is checked via `require(XXX_SPELL.codehash == XXX_SPELL_HASH, "XXX_SPELL/wrong-codehash");` inside Core spell
       * [ ] The Prime Agent spell is executed via `ProxyLike(XXX_PROXY).exec(XXX_SPELL, abi.encodeWithSignature("execute()"));`
   * IF `SUBPROXY_METHODS` transfers are present
-    * [ ] Each transfer is executed via `SubProxyLike(XXX_SUBPROXY).exec(SUBPROXY_METHODS, abi.encodeWithSelector(SubProxyMethodsLike.transfer.selector, TOKEN, RECIPIENT, AMOUNT_IN_WAD));`
+    * [ ] Each transfer is executed via `SubProxyLike(XXX_SUBPROXY).exec(SUBPROXY_METHODS, abi.encodeWithSelector(SubProxyMethodsLike.transfer.selector, TOKEN, RECIPIENT, AMOUNT));`
 * Add specific tests in `DssSpell.t.sol` to have sufficient test coverage for every spell action
   * [ ] Test new collaterals
   * [ ] Test new ilk registry values

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -151,6 +151,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Test new ChainLog values
   * [ ] Test DAI/USDS/SKY/SPK streams and payments, lerps
   * [ ] Test the sum of all DAI/USDS/SKY/SPK payments matches the Exec Sheet
+  * IF `SUBPROXY_METHODS` transfers are present
+    * [ ] Test each transfer from `XXX_SUBPROXY` with a pre-cast token balance check and exact `XXX_SUBPROXY`/recipient balance deltas
 * Run tests via `make test` (or `make test match=<test_name>` to inspect debug traces)
   * [ ] Ensure good coverage (every spell action is tested)
   * [ ] Ensure every test function is declared as `public`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -210,6 +210,15 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Transfer amount matches Exec Sheet
     * [ ] The transfers are tested via `testPayments` test
     * [ ] Sum of all USDS transfers tested in `testPayments` matches number in the Exec Sheet
+  * IF `SUBPROXY_METHODS` transfers are present
+    * [ ] `SUBPROXY_METHODS` is fetched from chainlog
+    * [ ] `XXX_SUBPROXY` is fetched from chainlog
+    * [ ] `XXX_SUBPROXY` matches the SubProxy named in the Exec Sheet
+    * [ ] Token transferred matches Exec Sheet
+    * [ ] Recipient address matches Exec Sheet
+    * [ ] Recipient address variable name matches one found in `addresses_wallets.sol`
+    * [ ] Transfer amount matches Exec Sheet
+    * [ ] Transfers from `XXX_SUBPROXY` are tested via pre-cast token balance checks and exact `XXX_SUBPROXY`/recipient balance deltas
   * IF `DAI` / `SKY` / `USDS` / `SPK` streams (`DssVest`) are created
     * [ ] `VestAbstract` interface is imported from `dss-interfaces/dss/VestAbstract.sol`
     * [ ] `restrict` is used for each stream, UNLESS otherwise explicitly stated in the Exec Sheet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -211,10 +211,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] The transfers are tested via `testPayments` test
     * [ ] Sum of all USDS transfers tested in `testPayments` matches number in the Exec Sheet
   * IF `SUBPROXY_METHODS` transfers are present
+    * [ ] Each transfer is executed via `SubProxyLike(XXX_SUBPROXY).exec(SUBPROXY_METHODS, abi.encodeWithSelector(SubProxyMethodsLike.transfer.selector, TOKEN, RECIPIENT, AMOUNT));`
     * [ ] `SUBPROXY_METHODS` is fetched from chainlog
     * [ ] `XXX_SUBPROXY` is fetched from chainlog
     * [ ] `XXX_SUBPROXY` matches the SubProxy named in the Exec Sheet
-    * [ ] Each transfer is executed via `SubProxyLike(XXX_SUBPROXY).exec(SUBPROXY_METHODS, abi.encodeWithSelector(SubProxyMethodsLike.transfer.selector, TOKEN, RECIPIENT, AMOUNT));`
     * [ ] `AMOUNT` has `TOKEN.decimals()` precision
     * [ ] Token transferred matches Exec Sheet
     * [ ] Recipient address in the instruction is in the checksummed format

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -214,7 +214,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] `SUBPROXY_METHODS` is fetched from chainlog
     * [ ] `XXX_SUBPROXY` is fetched from chainlog
     * [ ] `XXX_SUBPROXY` matches the SubProxy named in the Exec Sheet
+    * [ ] Each transfer is executed via `SubProxyLike(XXX_SUBPROXY).exec(SUBPROXY_METHODS, abi.encodeWithSelector(SubProxyMethodsLike.transfer.selector, TOKEN, RECIPIENT, AMOUNT_IN_WAD));`
     * [ ] Token transferred matches Exec Sheet
+    * [ ] Recipient address in the instruction is in the checksummed format
     * [ ] Recipient address matches Exec Sheet
     * [ ] Recipient address variable name matches one found in `addresses_wallets.sol`
     * [ ] Transfer amount matches Exec Sheet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -214,7 +214,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] `SUBPROXY_METHODS` is fetched from chainlog
     * [ ] `XXX_SUBPROXY` is fetched from chainlog
     * [ ] `XXX_SUBPROXY` matches the SubProxy named in the Exec Sheet
-    * [ ] Each transfer is executed via `SubProxyLike(XXX_SUBPROXY).exec(SUBPROXY_METHODS, abi.encodeWithSelector(SubProxyMethodsLike.transfer.selector, TOKEN, RECIPIENT, AMOUNT_IN_WAD));`
+    * [ ] Each transfer is executed via `SubProxyLike(XXX_SUBPROXY).exec(SUBPROXY_METHODS, abi.encodeWithSelector(SubProxyMethodsLike.transfer.selector, TOKEN, RECIPIENT, AMOUNT));`
     * [ ] Token transferred matches Exec Sheet
     * [ ] Recipient address in the instruction is in the checksummed format
     * [ ] Recipient address matches Exec Sheet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -215,7 +215,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] `XXX_SUBPROXY` is fetched from chainlog
     * [ ] `XXX_SUBPROXY` matches the SubProxy named in the Exec Sheet
     * [ ] Each transfer is executed via `SubProxyLike(XXX_SUBPROXY).exec(SUBPROXY_METHODS, abi.encodeWithSelector(SubProxyMethodsLike.transfer.selector, TOKEN, RECIPIENT, AMOUNT));`
-      * [ ] `AMOUNT` has `TOKEN.decimals()` precision
+    * [ ] `AMOUNT` has `TOKEN.decimals()` precision
     * [ ] Token transferred matches Exec Sheet
     * [ ] Recipient address in the instruction is in the checksummed format
     * [ ] Recipient address matches Exec Sheet

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -215,6 +215,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] `XXX_SUBPROXY` is fetched from chainlog
     * [ ] `XXX_SUBPROXY` matches the SubProxy named in the Exec Sheet
     * [ ] Each transfer is executed via `SubProxyLike(XXX_SUBPROXY).exec(SUBPROXY_METHODS, abi.encodeWithSelector(SubProxyMethodsLike.transfer.selector, TOKEN, RECIPIENT, AMOUNT));`
+      * [ ] `AMOUNT` has `TOKEN.decimals()` precision
     * [ ] Token transferred matches Exec Sheet
     * [ ] Recipient address in the instruction is in the checksummed format
     * [ ] Recipient address matches Exec Sheet


### PR DESCRIPTION
This PR adds checklist coverage for `SUBPROXY_METHODS` transfers:
- Updating crafter checklist with the expected SubProxy transfer call pattern
- Updating reviewer checklist with SubProxy transfer review checks