### PR TITLE
Add SafeHarbor coverage controls

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,4 +1,5 @@
 AGPLv
+ABI
 ALM
 Antipatterns
 AutoLine

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -6,6 +6,7 @@ AutoLine
 Calc
 CalcFab
 ChainLog
+CLI
 Cleanup
 ClipFab
 Crafter

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -131,7 +131,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Adjust system values, collateral values inside `config.sol`
   * [ ] Ensure every spell variable is declared as public/internal
   * Bug Bounty Registry Updates
-    * [ ] Review the approved SafeHarbor source data and check that output of `make safeharbor-generate` matches the instructions provided by Governance Facilitators
+    * [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) and check that output of `make safeharbor-generate` matches the instructions provided by Governance Facilitators
       * [ ] IF no instructions were provided and script produces "no changes", then no further action is required
       * [ ] IF there is a mismatch, crafter should notify Governance Facilitators
       * [ ] IF the scripts outputs a warning indicated by ⚠️ ❗, notify Governance Facilitators

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -234,6 +234,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Check that returned `public explorer url` is publicly accessible (e.g. using incognito browser mode)
   * [ ] IF `cast-on-tenderly` command is executed several times for the same spell, delete all testnets of the same name except the last one
 * SafeHarbor registry post-cast reconciliation
+  * [ ] Set `ETH_RPC_URL` to the Tenderly Testnet RPC URL
   * [ ] Run `make safeharbor-generate` in the Tenderly Testnet environment after the spell is cast
   * [ ] Ensure it returns "no updates" and no validation warnings (⚠️ ❗)
 * [ ] Archive Spell via `make archive-spell` for the current date (or `make archive-spell date="YYYY-MM-DD"`) using Target Date inside the Exec Doc

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -131,7 +131,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Adjust system values, collateral values inside `config.sol`
   * [ ] Ensure every spell variable is declared as public/internal
   * Bug Bounty Registry Updates
-    * [ ] Check that output of `make safeharbor-generate` matches the instructions provided by Governance Facilitators
+    * [ ] Review the approved SafeHarbor source data and check that output of `make safeharbor-generate` matches the instructions provided by Governance Facilitators
       * [ ] IF no instructions were provided and script produces "no changes", then no further action is required
       * [ ] IF there is a mismatch, crafter should notify Governance Facilitators
       * [ ] IF the scripts outputs a warning indicated by ⚠️ ❗, notify Governance Facilitators
@@ -162,8 +162,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Sanity checks of the constructor arguments
     * [ ] Sanity checks of all values added/updated by the spell function
     * [ ] End-to-end "happy path" interaction with the module
-  * IF bug bounty updates are present
-    * [ ] Test that all bug bounty registry calls execute successfully
+  * IF SafeHarbor registry updates are present
+    * [ ] SafeHarbor registry updates are exempt from Solidity-side test coverage
+    * [ ] Ensure `scripts/safeharbor` tests cover every supported state-diff operation and snapshot both raw calldata and ABI-decoded calldata
   * [ ] Tests PASS via `make test`
 * [ ] Ensure `DssExecLib` address used in current spell (`libraries` inside `foundry.toml`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/sky-ecosystem/dss-exec-lib/releases/latest)
 * [ ] Push committed content to already opened PR
@@ -232,7 +233,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Create testnet and cast deployed spell there using `make cast-on-tenderly spell=0x...` command
   * [ ] Check that returned `public explorer url` is publicly accessible (e.g. using incognito browser mode)
   * [ ] IF `cast-on-tenderly` command is executed several times for the same spell, delete all testnets of the same name except the last one
-* [ ] `make safeharbor-generate` returns "no updates" in the testnet environment after spell was cast
+* SafeHarbor registry post-cast reconciliation
+  * [ ] Run `make safeharbor-generate` in the Tenderly Testnet environment after the spell is cast
+  * [ ] Ensure it returns "no updates" and no validation warnings (⚠️ ❗)
 * [ ] Archive Spell via `make archive-spell` for the current date (or `make archive-spell date="YYYY-MM-DD"`) using Target Date inside the Exec Doc
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -66,8 +66,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * Ensure correctness of the cleanup
     * [ ] Run Tests `make test` (or `make test match=<test_name>` to inspect debug traces)
   * [ ] Commit the cleanup (e.g. `git commit -am "Base spell"`)
-* [ ] Run `make safeharbor-generate` to ensure that updates match the bug bounty updates instructions on the Exec Sheet
-  * [ ] IF there is a mismatch, notify Governance Facilitators
+* [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) as the source of truth for the desired registry state
+  * [ ] Run `make safeharbor-generate` and ensure the generated updates implement the spreadsheet state relative to the current agreement
+  * [ ] IF there is a mismatch or validation warning, run `make safeharbor-inspect` to review the structured updates and warnings, then notify Governance Facilitators
 * Add comments to the spell based on the relevant [Exec Sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
   * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code
   * [ ] Surround the comment by the set of dashes (e.g. `// ----- Section text -----`)
@@ -131,12 +132,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Adjust system values, collateral values inside `config.sol`
   * [ ] Ensure every spell variable is declared as public/internal
   * Bug Bounty Registry Updates
-    * [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) and check that output of `make safeharbor-generate` matches the instructions provided by Governance Facilitators
-      * [ ] IF no instructions were provided and script produces "no changes", then no further action is required
-      * [ ] IF there is a mismatch, crafter should notify Governance Facilitators
-      * [ ] IF the scripts outputs a warning indicated by ⚠️ ❗, notify Governance Facilitators
-      * [ ] IF the command outputs a solidity snippet that matches the instructions provided by Governance Facilitators:
+    * [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) as the source of truth for the desired registry state
+      * [ ] Run `make safeharbor-generate` and verify that the generated payload implements the spreadsheet state relative to the current agreement
+      * [ ] Review all validation warnings
+      * [ ] IF there is a mismatch or validation warning, run `make safeharbor-inspect` to review the structured updates and warnings, then notify Governance Facilitators
+      * [ ] IF the generated Solidity snippet is required by the spreadsheet state:
         * [ ] Paste the generated code into the spell as is. The code should not be modified. You may adjust formatting
+        * [ ] Verify that the generated SafeHarbor payload exactly matches the payload in the spell
         * [ ] Fetch the agreement address from the `ChainLog`
         * [ ] IF not already present, add the helper function to perform the call, using the established archive pattern
   * IF Prime Agent spell is provided
@@ -164,7 +166,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] End-to-end "happy path" interaction with the module
   * IF SafeHarbor registry updates are present
     * [ ] SafeHarbor registry updates are exempt from Solidity-side test coverage
-    * [ ] Ensure `scripts/safeharbor` tests cover every supported state-diff operation and snapshot both raw calldata and ABI-decoded calldata
+    * [ ] Ensure `scripts/safeharbor` generator tests are case-complete for valid and invalid state transitions, including executable add/remove ordering
+    * [ ] Ensure the tests cover structured validation warnings and CLI status behavior
+    * [ ] Ensure the tests snapshot both raw calldata and ABI-decoded calldata
   * [ ] Tests PASS via `make test`
 * [ ] Ensure `DssExecLib` address used in current spell (`libraries` inside `foundry.toml`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/sky-ecosystem/dss-exec-lib/releases/latest)
 * [ ] Push committed content to already opened PR
@@ -235,8 +239,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] IF `cast-on-tenderly` command is executed several times for the same spell, delete all testnets of the same name except the last one
 * SafeHarbor registry post-cast reconciliation
   * [ ] Set `ETH_RPC_URL` to the Tenderly Testnet RPC URL
-  * [ ] Run `make safeharbor-generate` in the Tenderly Testnet environment after the spell is cast
-  * [ ] Ensure it returns "no updates" and no validation warnings (⚠️ ❗)
+  * [ ] Run `make safeharbor-verify` in the Tenderly Testnet environment after the spell is cast
+  * [ ] Ensure the verification succeeds
+  * IF verification fails
+    * [ ] Run `make safeharbor-inspect` to review the structured updates and validation warnings before escalating the mismatch
 * [ ] Archive Spell via `make archive-spell` for the current date (or `make archive-spell date="YYYY-MM-DD"`) using Target Date inside the Exec Doc
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -68,7 +68,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Commit the cleanup (e.g. `git commit -am "Base spell"`)
 * SafeHarbor source and proposed updates
   * [ ] Confirm the [SafeHarbor Sheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) is reviewed and approved for this spell, including intended accounts, scopes, and recovery addresses
-  * [ ] Use Node.js 24 and set `ETH_RPC_URL` to Ethereum mainnet or the intended pre-cast fork
+  * [ ] Use `Node.js 24` and set `ETH_RPC_URL` to Ethereum mainnet or the intended pre-cast fork
   * [ ] Run `make safeharbor-generate`; require successful generation with no validation warnings
   * [ ] Check that the proposed changes, including removals, implement the approved Sheet relative to the current Agreement
   * IF generation fails or proposes unexpected changes
@@ -166,7 +166,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * Scope updates use generator coverage, payload review, and post-cast reconciliation instead of a separate Solidity traversal test; other Agreement changes still require appropriate tests
     * [ ] Run `npm test --prefix scripts/safeharbor -- --run` and confirm the SafeHarbor suite passes for the spell revision
     * [ ] Confirm coverage for the operations used by the spell, including replacement ordering and scope changes where applicable
-  * IF SafeHarbor scripts, Makefile commands, or their CI workflow changed
+  * IF SafeHarbor scripts, `Makefile` commands, or their CI workflow changed
     * [ ] Review coverage for chain/account additions, removals, replacements, scope changes, rejected input, warning blocking, and command failures
     * [ ] Review changed expected operations and raw calldata, ABI-decoded calldata, and Solidity snapshots; do not accept regenerated snapshots without checking their meaning
     * [ ] Ensure the SafeHarbor CI tests, lint, and formatting checks pass

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -66,9 +66,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * Ensure correctness of the cleanup
     * [ ] Run Tests `make test` (or `make test match=<test_name>` to inspect debug traces)
   * [ ] Commit the cleanup (e.g. `git commit -am "Base spell"`)
-* [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) as the source of truth for the desired registry state
-  * [ ] Run `make safeharbor-generate` and ensure the generated updates implement the spreadsheet state relative to the current agreement
-  * [ ] IF there is a mismatch or validation warning, run `make safeharbor-inspect` to review the structured updates and warnings, then notify Governance Facilitators
+* SafeHarbor source and proposed updates
+  * [ ] Confirm the [SafeHarbor Sheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) is reviewed and approved for this spell, including intended accounts, scopes, and recovery addresses
+  * [ ] Use Node.js 24 and set `ETH_RPC_URL` to Ethereum mainnet or the intended pre-cast fork
+  * [ ] Run `make safeharbor-generate`; require successful generation with no validation warnings
+  * [ ] Check that the proposed changes, including removals, implement the approved Sheet relative to the current Agreement
+  * IF generation fails or proposes unexpected changes
+    * [ ] Use `make safeharbor-inspect` to investigate the source data, proposed changes, and warnings; resolve issues with Governance Facilitators before using the payload
 * Add comments to the spell based on the relevant [Exec Sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
   * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code
   * [ ] Surround the comment by the set of dashes (e.g. `// ----- Section text -----`)
@@ -131,16 +135,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Removals are tested via `testRemovedChainlogKeys`
   * [ ] Adjust system values, collateral values inside `config.sol`
   * [ ] Ensure every spell variable is declared as public/internal
-  * Bug Bounty Registry Updates
-    * [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) as the source of truth for the desired registry state
-      * [ ] Run `make safeharbor-generate` and verify that the generated payload implements the spreadsheet state relative to the current agreement
-      * [ ] Review all validation warnings
-      * [ ] IF there is a mismatch or validation warning, run `make safeharbor-inspect` to review the structured updates and warnings, then notify Governance Facilitators
-      * [ ] IF the generated Solidity snippet is required by the spreadsheet state:
-        * [ ] Paste the generated code into the spell as is. The code should not be modified. You may adjust formatting
-        * [ ] Verify that the generated SafeHarbor payload exactly matches the payload in the spell
-        * [ ] Fetch the agreement address from the `ChainLog`
-        * [ ] IF not already present, add the helper function to perform the call, using the established archive pattern
+  * IF SafeHarbor registry updates are present
+    * [ ] Paste the generated snippet into the spell unchanged, except for formatting; verify every calldata entry and its order match the generated payload
+    * [ ] Fetch the Agreement address from the `SAFE_HARBOR_AGREEMENT` Chainlog entry
+    * [ ] Use the established archive helper pattern to execute calls in order and revert on any failed call
   * IF Prime Agent spell is provided
     * [ ] Handover message matches `XXX spell YYYY-MM-DD deployed to 0x… with hash 0x…, direct execution: yes / no` template
     * [ ] IF `direct execution` is `no`
@@ -150,7 +148,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * [ ] The Prime Agent spell is executed via `ProxyLike(XXX_PROXY).exec(XXX_SPELL, abi.encodeWithSignature("execute()"));`
   * IF `SUBPROXY_METHODS` transfers are present
     * [ ] Each transfer is executed via `SubProxyLike(XXX_SUBPROXY).exec(SUBPROXY_METHODS, abi.encodeWithSelector(SubProxyMethodsLike.transfer.selector, TOKEN, RECIPIENT, AMOUNT));`
-* Add specific tests in `DssSpell.t.sol` to have sufficient test coverage for every spell action
+* Add specific tests in `DssSpell.t.sol` to have sufficient test coverage for every spell action, except SafeHarbor scope updates covered below
   * [ ] Test new collaterals
   * [ ] Test new ilk registry values
   * [ ] Test new ChainLog values
@@ -165,10 +163,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Sanity checks of all values added/updated by the spell function
     * [ ] End-to-end "happy path" interaction with the module
   * IF SafeHarbor registry updates are present
-    * [ ] SafeHarbor registry updates are exempt from Solidity-side test coverage
-    * [ ] Ensure `scripts/safeharbor` generator tests are case-complete for valid and invalid state transitions, including executable add/remove ordering
-    * [ ] Ensure the tests cover structured validation warnings and CLI status behavior
-    * [ ] Ensure the tests snapshot both raw calldata and ABI-decoded calldata
+    * Scope updates use generator coverage, payload review, and post-cast reconciliation instead of a separate Solidity traversal test; other Agreement changes still require appropriate tests
+    * [ ] Run `npm test --prefix scripts/safeharbor -- --run` and confirm the SafeHarbor suite passes for the spell revision
+    * [ ] Confirm coverage for the operations used by the spell, including replacement ordering and scope changes where applicable
+  * IF SafeHarbor scripts, Makefile commands, or their CI workflow changed
+    * [ ] Review coverage for chain/account additions, removals, replacements, scope changes, rejected input, warning blocking, and command failures
+    * [ ] Review changed expected operations and raw calldata, ABI-decoded calldata, and Solidity snapshots; do not accept regenerated snapshots without checking their meaning
+    * [ ] Ensure the SafeHarbor CI tests, lint, and formatting checks pass
   * [ ] Tests PASS via `make test`
 * [ ] Ensure `DssExecLib` address used in current spell (`libraries` inside `foundry.toml`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/sky-ecosystem/dss-exec-lib/releases/latest)
 * [ ] Push committed content to already opened PR
@@ -238,11 +239,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Check that returned `public explorer url` is publicly accessible (e.g. using incognito browser mode)
   * [ ] IF `cast-on-tenderly` command is executed several times for the same spell, delete all testnets of the same name except the last one
 * SafeHarbor registry post-cast reconciliation
-  * [ ] Set `ETH_RPC_URL` to the Tenderly Testnet RPC URL
-  * [ ] Run `make safeharbor-verify` in the Tenderly Testnet environment after the spell is cast
-  * [ ] Ensure the verification succeeds
+  * [ ] Set `ETH_RPC_URL` to the RPC URL of the Tenderly Testnet where the exact deployed spell was cast
+  * [ ] Confirm the Sheet still matches the approved source reviewed above; repeat source and payload review if it changed
+  * [ ] Run `make safeharbor-verify` after the cast, even if the spell contains no SafeHarbor updates; require success with no updates and no validation warnings
   * IF verification fails
-    * [ ] Run `make safeharbor-inspect` to review the structured updates and validation warnings before escalating the mismatch
+    * [ ] Use `make safeharbor-inspect` to investigate, resolve the failure with Governance Facilitators, and rerun verification before handover
+    * Successful inspection or an empty changes list is not proof of a match; warnings can block change calculation
 * [ ] Archive Spell via `make archive-spell` for the current date (or `make archive-spell date="YYYY-MM-DD"`) using Target Date inside the Exec Doc
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
@@ -250,6 +252,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * Foundry installation logs containing installed versions (from above)
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
+  * Successful SafeHarbor post-cast verification output
 * [ ] Notify the reviewers (e.g. "the spell was deployed")
 * [ ] IF everything is on track, the sync call can be cancelled with agreement from the spell team
 

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -333,6 +333,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] IF the test needs to run, it MUST NOT have the `skipped` modifier; OTHERWISE, it MUST have the `skipped` modifier
   * [ ] Ensure each spell action has sufficient test coverage
     _List actions for which coverage was checked here_
+    * IF SafeHarbor registry updates are present
+      * [ ] SafeHarbor registry updates are exempt from Solidity-side test coverage
+      * [ ] Review the approved SafeHarbor source data
+      * [ ] Ensure `scripts/safeharbor` tests cover every supported state-diff operation and snapshot both raw calldata and ABI-decoded calldata
+      * [ ] Verify that the generated SafeHarbor payload exactly matches the payload in the spell
   * [ ] Ensure that any other env variable does not affect execution of the tests (for example, by inspecting the output of `printenv | grep "FOUNDRY_\|DAPP_"`)
   * IF a new module is initialized via the spell, the tests must include
     * [ ] Sanity checks of the constructor arguments
@@ -426,8 +431,7 @@ _Insert your local test logs here_
   * [ ] All actions are executed in the transaction trace
   * [ ] No reverts are present that block execution
   * [ ] No out-of-gas errors are present
-  * [ ] `make safeharbor-generate` against the testnet returns "no updates"
-    * [ ] IF the script outputs a warning indicated by ⚠️ ❗, notify Governance Facilitators
+  * [ ] `make safeharbor-generate` against the testnet returns "no updates" and no validation warnings (⚠️ ❗)
 * Archive checks
   * [ ] `make diff-archive-spell` for current date or `make diff-archive-spell date="YYYY-MM-DD"`
   * [ ] Ensure date corresponds to target Exec Doc date

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -431,6 +431,7 @@ _Insert your local test logs here_
   * [ ] All actions are executed in the transaction trace
   * [ ] No reverts are present that block execution
   * [ ] No out-of-gas errors are present
+  * [ ] Set `ETH_RPC_URL` to the Tenderly Testnet RPC URL
   * [ ] `make safeharbor-generate` against the testnet returns "no updates" and no validation warnings (⚠️ ❗)
 * Archive checks
   * [ ] `make diff-archive-spell` for current date or `make diff-archive-spell date="YYYY-MM-DD"`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -335,7 +335,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _List actions for which coverage was checked here_
     * IF SafeHarbor registry updates are present
       * [ ] SafeHarbor registry updates are exempt from Solidity-side test coverage
-      * [ ] Review the approved SafeHarbor source data
+      * [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U)
       * [ ] Ensure `scripts/safeharbor` tests cover every supported state-diff operation and snapshot both raw calldata and ABI-decoded calldata
       * [ ] Verify that the generated SafeHarbor payload exactly matches the payload in the spell
   * [ ] Ensure that any other env variable does not affect execution of the tests (for example, by inspecting the output of `printenv | grep "FOUNDRY_\|DAPP_"`)

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -19,8 +19,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Office hours is `true` IF spell introduces a major change that can affect external parties (e.g.: keepers are affected in case of collateral offboarding) OTHERWISE explicitly set to `false`
   * [ ] Office hours value matches the Exec Sheet
   * [ ] 30 days spell expiry set in the constructor (`block.timestamp + 30 days`)
-* [ ] `make safeharbor-generate` output matches the instructions on the Exec Sheet
-  * [ ] IF there is a mismatch, notify Governance Facilitators
+* [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) as the source of truth for the desired registry state
+  * [ ] Run `make safeharbor-generate` and ensure the generated updates implement the spreadsheet state relative to the current agreement
+  * [ ] IF there is a mismatch or validation warning, run `make safeharbor-inspect` to review the structured updates and warnings, then notify Governance Facilitators
 * Spell description
   * [ ] Description follows the format `TARGET_DATE MakerDAO Executive Spell | Hash: EXEC_DOC_HASH`
   * [ ] `TARGET_DATE` in the description matches the target date
@@ -307,10 +308,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Target Contract is included in the ChainLog
   * [ ] Test Coverage is comprehensive
 * IF bug bounty registry updates are present
+  * [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) as the source of truth for the desired registry state
   * [ ] Run `make safeharbor-generate`
     * [ ] Verify that the generated code exactly matches the code in the spell
-    * [ ] Verify that output matches the instructions provided by Governance Facilitators
-    * [ ] Ensure that the script does not output any warnings, which are indicated by ⚠️ ❗
+    * [ ] Verify that the generated payload implements the spreadsheet state relative to the current agreement
+    * [ ] Review all validation warnings
+    * [ ] IF there is a mismatch or validation warning, run `make safeharbor-inspect` to review the structured updates and warnings, then notify Governance Facilitators
   * [ ] Ensure that agreement address is fetched from the Chainlog
   * [ ] Ensure that the helper function to perform the call is present and is implemented using the established archive pattern
 * IF spell interacts with ChainLog
@@ -335,8 +338,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     _List actions for which coverage was checked here_
     * IF SafeHarbor registry updates are present
       * [ ] SafeHarbor registry updates are exempt from Solidity-side test coverage
-      * [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U)
-      * [ ] Ensure `scripts/safeharbor` tests cover every supported state-diff operation and snapshot both raw calldata and ABI-decoded calldata
+      * [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) as the source of truth for the desired registry state
+      * [ ] Ensure `scripts/safeharbor` generator tests are case-complete for valid and invalid state transitions, including executable add/remove ordering
+      * [ ] Ensure the tests cover structured validation warnings and CLI status behavior
+      * [ ] Ensure the tests snapshot both raw calldata and ABI-decoded calldata
       * [ ] Verify that the generated SafeHarbor payload exactly matches the payload in the spell
   * [ ] Ensure that any other env variable does not affect execution of the tests (for example, by inspecting the output of `printenv | grep "FOUNDRY_\|DAPP_"`)
   * IF a new module is initialized via the spell, the tests must include
@@ -432,7 +437,10 @@ _Insert your local test logs here_
   * [ ] No reverts are present that block execution
   * [ ] No out-of-gas errors are present
   * [ ] Set `ETH_RPC_URL` to the Tenderly Testnet RPC URL
-  * [ ] `make safeharbor-generate` against the testnet returns "no updates" and no validation warnings (⚠️ ❗)
+  * [ ] Run `make safeharbor-verify` against the Tenderly Testnet after the spell is cast
+  * [ ] Ensure the verification succeeds
+  * IF verification fails
+    * [ ] Run `make safeharbor-inspect` to review the structured updates and validation warnings before escalating the mismatch
 * Archive checks
   * [ ] `make diff-archive-spell` for current date or `make diff-archive-spell date="YYYY-MM-DD"`
   * [ ] Ensure date corresponds to target Exec Doc date

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -19,9 +19,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Office hours is `true` IF spell introduces a major change that can affect external parties (e.g.: keepers are affected in case of collateral offboarding) OTHERWISE explicitly set to `false`
   * [ ] Office hours value matches the Exec Sheet
   * [ ] 30 days spell expiry set in the constructor (`block.timestamp + 30 days`)
-* [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) as the source of truth for the desired registry state
-  * [ ] Run `make safeharbor-generate` and ensure the generated updates implement the spreadsheet state relative to the current agreement
-  * [ ] IF there is a mismatch or validation warning, run `make safeharbor-inspect` to review the structured updates and warnings, then notify Governance Facilitators
+* SafeHarbor source and proposed updates
+  * [ ] Independently review the approved [SafeHarbor Sheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U), including intended accounts, scopes, and recovery addresses
+  * [ ] Use Node.js 24 and set `ETH_RPC_URL` to Ethereum mainnet or the intended pre-cast fork
+  * [ ] Run `make safeharbor-generate`; require successful generation with no validation warnings
+  * [ ] Check that the proposed changes, including removals, implement the approved Sheet relative to the current Agreement and that none are missing from or added to the spell
+  * IF generation fails or proposes unexpected changes
+    * [ ] Use `make safeharbor-inspect` to investigate the source data, proposed changes, and warnings; resolve issues with Governance Facilitators before approving the payload
 * Spell description
   * [ ] Description follows the format `TARGET_DATE MakerDAO Executive Spell | Hash: EXEC_DOC_HASH`
   * [ ] `TARGET_DATE` in the description matches the target date
@@ -307,15 +311,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Target contract is not upgradable
   * [ ] Target Contract is included in the ChainLog
   * [ ] Test Coverage is comprehensive
-* IF bug bounty registry updates are present
-  * [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) as the source of truth for the desired registry state
-  * [ ] Run `make safeharbor-generate`
-    * [ ] Verify that the generated code exactly matches the code in the spell
-    * [ ] Verify that the generated payload implements the spreadsheet state relative to the current agreement
-    * [ ] Review all validation warnings
-    * [ ] IF there is a mismatch or validation warning, run `make safeharbor-inspect` to review the structured updates and warnings, then notify Governance Facilitators
-  * [ ] Ensure that agreement address is fetched from the Chainlog
-  * [ ] Ensure that the helper function to perform the call is present and is implemented using the established archive pattern
+* IF SafeHarbor registry updates are present
+  * [ ] Verify the spell matches the generated snippet, except for formatting, including every calldata entry and its order
+  * [ ] Ensure the Agreement address is fetched from the `SAFE_HARBOR_AGREEMENT` Chainlog entry
+  * [ ] Ensure the helper follows the established archive pattern, executing calls in order and reverting on any failed call
 * IF spell interacts with ChainLog
   * [ ] ChainLog version is incremented based on update type
     * Major -> New Vat (++.0.0)
@@ -337,19 +336,20 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Ensure each spell action has sufficient test coverage
     _List actions for which coverage was checked here_
     * IF SafeHarbor registry updates are present
-      * [ ] SafeHarbor registry updates are exempt from Solidity-side test coverage
-      * [ ] Review the approved [SafeHarbor source spreadsheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U) as the source of truth for the desired registry state
-      * [ ] Ensure `scripts/safeharbor` generator tests are case-complete for valid and invalid state transitions, including executable add/remove ordering
-      * [ ] Ensure the tests cover structured validation warnings and CLI status behavior
-      * [ ] Ensure the tests snapshot both raw calldata and ABI-decoded calldata
-      * [ ] Verify that the generated SafeHarbor payload exactly matches the payload in the spell
+      * Scope updates use generator coverage, payload review, and post-cast reconciliation instead of a separate Solidity traversal test; other Agreement changes still require appropriate tests
+      * [ ] Run `npm test --prefix scripts/safeharbor -- --run` and confirm the SafeHarbor suite passes for the spell revision
+      * [ ] Confirm coverage for the operations used by the spell, including replacement ordering and scope changes where applicable
+  * IF SafeHarbor scripts, Makefile commands, or their CI workflow changed
+    * [ ] Review coverage for chain/account additions, removals, replacements, scope changes, rejected input, warning blocking, and command failures
+    * [ ] Review changed expected operations and raw calldata, ABI-decoded calldata, and Solidity snapshots; do not accept regenerated snapshots without checking their meaning
+    * [ ] Ensure the SafeHarbor CI tests, lint, and formatting checks pass
   * [ ] Ensure that any other env variable does not affect execution of the tests (for example, by inspecting the output of `printenv | grep "FOUNDRY_\|DAPP_"`)
   * IF a new module is initialized via the spell, the tests must include
     * [ ] Sanity checks of the constructor arguments
     * [ ] Sanity checks of all values added/updated by the spell function
     * [ ] End-to-end "happy path" interaction with the module
   * [ ] Check all tests are passing locally using `make test`
-    * [ ] Ensure every test listed in the _coverage_ item above is present in the logs and with the `[PASS]` prefix.
+    * [ ] Ensure every Solidity test listed in the _coverage_ item above is present in the logs and with the `[PASS]` prefix.
 
 ```
 _Insert your local test logs here_
@@ -436,11 +436,13 @@ _Insert your local test logs here_
   * [ ] All actions are executed in the transaction trace
   * [ ] No reverts are present that block execution
   * [ ] No out-of-gas errors are present
-  * [ ] Set `ETH_RPC_URL` to the Tenderly Testnet RPC URL
-  * [ ] Run `make safeharbor-verify` against the Tenderly Testnet after the spell is cast
-  * [ ] Ensure the verification succeeds
+  * [ ] Set `ETH_RPC_URL` to the RPC URL of the Tenderly Testnet where the exact deployed spell was cast
+  * [ ] Confirm the Sheet still matches the approved source reviewed above; repeat source and payload review if it changed
+  * [ ] Independently run `make safeharbor-verify` after the cast, even if the spell contains no SafeHarbor updates; require success with no updates and no validation warnings
+  * [ ] Record the successful verification output with the review evidence
   * IF verification fails
-    * [ ] Run `make safeharbor-inspect` to review the structured updates and validation warnings before escalating the mismatch
+    * [ ] Use `make safeharbor-inspect` to investigate, resolve the failure with Governance Facilitators, and rerun verification before handover
+    * Successful inspection or an empty changes list is not proof of a match; warnings can block change calculation
 * Archive checks
   * [ ] `make diff-archive-spell` for current date or `make diff-archive-spell date="YYYY-MM-DD"`
   * [ ] Ensure date corresponds to target Exec Doc date

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -21,7 +21,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] 30 days spell expiry set in the constructor (`block.timestamp + 30 days`)
 * SafeHarbor source and proposed updates
   * [ ] Independently review the approved [SafeHarbor Sheet](https://docs.google.com/spreadsheets/d/1e_KOYOeBGaA5EG3Xqco6lOP_a0zV4Vrm3w5-dqFk00U), including intended accounts, scopes, and recovery addresses
-  * [ ] Use Node.js 24 and set `ETH_RPC_URL` to Ethereum mainnet or the intended pre-cast fork
+  * [ ] Use `Node.js 24` and set `ETH_RPC_URL` to Ethereum mainnet or the intended pre-cast fork
   * [ ] Run `make safeharbor-generate`; require successful generation with no validation warnings
   * [ ] Check that the proposed changes, including removals, implement the approved Sheet relative to the current Agreement and that none are missing from or added to the spell
   * IF generation fails or proposes unexpected changes
@@ -339,7 +339,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * Scope updates use generator coverage, payload review, and post-cast reconciliation instead of a separate Solidity traversal test; other Agreement changes still require appropriate tests
       * [ ] Run `npm test --prefix scripts/safeharbor -- --run` and confirm the SafeHarbor suite passes for the spell revision
       * [ ] Confirm coverage for the operations used by the spell, including replacement ordering and scope changes where applicable
-  * IF SafeHarbor scripts, Makefile commands, or their CI workflow changed
+  * IF SafeHarbor scripts, `Makefile` commands, or their CI workflow changed
     * [ ] Review coverage for chain/account additions, removals, replacements, scope changes, rejected input, warning blocking, and command failures
     * [ ] Review changed expected operations and raw calldata, ABI-decoded calldata, and Solidity snapshots; do not accept regenerated snapshots without checking their meaning
     * [ ] Ensure the SafeHarbor CI tests, lint, and formatting checks pass


### PR DESCRIPTION
## Summary

Align the mainnet crafter and reviewer checklists with [spells-mainnet#558](https://github.com/sky-ecosystem/spells-mainnet/pull/558):

- Review and approve the SafeHarbor Sheet.
- Generate against the current Agreement without validation warnings, then confirm the spell uses the exact generated calldata and call order.
- Treat SafeHarbor scope updates as exempt from separate `DssSpell.t.sol` coverage; SafeHarbor script maintenance and test execution stay outside the spell workflow.
- Cast the exact deployed spell on Tenderly and run `make safeharbor-verify` against the simulated post-state and approved Sheet, requiring no updates or validation warnings even when the spell has no SafeHarbor changes.

This PR remains in draft.