### PR TITLE
feat: add octane review to core spell checklist

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,3 +1,4 @@
+ABI
 AGPLv
 ALM
 Antipatterns

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -202,14 +202,21 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Exec hash is correct (use `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"` where `wget` doesn't work)
   * [ ] Ensure `description` date in `DssSpell.sol` matches target date inside Exec Doc
 * Octane Review
-  * [ ] Check if there is an existing Octane analysis on the latest commit on [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23) 
-    * [ ] OTHERWISE, trigger new analysis by pressing "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis"
-    * [ ] List every reported findings (split into separate items when one findings contains multiple issues):
-      1. Title [Octane URL]
-        * Link to the relevant code block: [GitHub permalink]
-        * Is this issue blocking spell deployment?
-        * Reason:
-    * [ ] IF any blocking issue is found, raise it to the current spell signal group
+  * [ ] IF no Octane analysis exists on the latest commit from [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23), trigger a new one (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
+  * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
+  * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
+  * [ ] List every reported vulnerability and warning (split into separate items when one finding contains multiple different issues):
+    1. Title [Octane URL]
+      * Link to the relevant code block: [GitHub permalink]
+      * Is this issue blocking spell deployment?
+      * Required reason (explain why it can be a problem or can't be):
+  * [ ] IF any blocking issue is found, raise it to the current spell signal group
+* IF new commits are present in the spell
+  * [ ] Copy relevant checklist items from the above and redo them
+  * [ ] Ensure newly added code is covered by tests
+  * [ ] Check if chainlog needs to be updated
+  * [ ] Copy over and redo "Tests" section from the above
+  * [ ] IF the spell code has been updated, redo the "Octane Review" section from above
 * [ ] Make sure all review comments are either addressed or explicitly answered
 * [ ] Make sure all items in the Exec Sheet are confirmed, OTHERWISE notify Responsible Governance Facilitator
 * [ ] Notify the reviewers (e.g. "Exec Hash is added, reviews are addressed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -204,12 +204,12 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Octane Review
   * [ ] Check if there is an existing Octane analysis on the latest commit on [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23) 
     * [ ] OTHERWISE, trigger new analysis by pressing "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis"
-    * [ ] List every identified issues (split issues into multiple ones when one issue actually contains multiple issues):
-      1. Issue title [Octane URL]
-        * Link to the relevant code block: [GitHub link or file]
+    * [ ] List every reported findings (split into separate items when one findings contains multiple issues):
+      1. Title [Octane URL]
+        * Link to the relevant code block: [GitHub permalink]
         * Is this issue blocking spell deployment?
         * Reason:
-    * [ ] IF any blocking issue is found, raise it to spell channel
+    * [ ] IF any blocking issue is found, raise it to the current spell signal group
 * [ ] Make sure all review comments are either addressed or explicitly answered
 * [ ] Make sure all items in the Exec Sheet are confirmed, OTHERWISE notify Responsible Governance Facilitator
 * [ ] Notify the reviewers (e.g. "Exec Hash is added, reviews are addressed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -201,6 +201,15 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       ```
   * [ ] Exec hash is correct (use `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"` where `wget` doesn't work)
   * [ ] Ensure `description` date in `DssSpell.sol` matches target date inside Exec Doc
+* Octane Review
+  * [ ] Check if there is an existing Octane analysis on the latest commit on [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23) 
+    * [ ] OTHERWISE, trigger new analysis by pressing "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis"
+    * [ ] List every identified issues (split issues into multiple ones when one issue actually contains multiple issues):
+      1. Issue title [Octane URL]
+        * Link to the relevant code block: [GitHub link or file]
+        * Is this issue blocking spell deployment?
+        * Reason:
+    * [ ] IF any blocking issue is found, raise it to spell channel
 * [ ] Make sure all review comments are either addressed or explicitly answered
 * [ ] Make sure all items in the Exec Sheet are confirmed, OTHERWISE notify Responsible Governance Facilitator
 * [ ] Notify the reviewers (e.g. "Exec Hash is added, reviews are addressed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -212,12 +212,6 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * Is this issue blocking spell deployment?
       * Required reason (explain why it can be a problem or can't be):
   * [ ] IF any blocking issue is found, raise it to the current spell signal group
-* IF new commits are present in the spell
-  * [ ] Copy relevant checklist items from the above and redo them
-  * [ ] Ensure newly added code is covered by tests
-  * [ ] Check if chainlog needs to be updated
-  * [ ] Copy over and redo "Tests" section from the above
-  * [ ] IF the spell code has been updated, redo the "Octane Review" section from above
 * [ ] Make sure all review comments are either addressed or explicitly answered
 * [ ] Make sure all items in the Exec Sheet are confirmed, OTHERWISE notify Responsible Governance Facilitator
 * [ ] Notify the reviewers (e.g. "Exec Hash is added, reviews are addressed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -204,6 +204,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Octane Review
   * [ ] IF no Octane analysis exists on the latest commit from [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23), trigger a new one (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
+  * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
   * [ ] List every reported vulnerability and warning (split into separate items when one finding contains multiple different issues):
     1. Title [Octane URL]

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -211,8 +211,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Find the most recent "Sky Ecosystem: Spells mainnet" Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
   * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", trigger a new analysis
     * [ ] Ensure the "SCOPE" for "project" is standardized to include:
-      * [ ] src/DssSpell.sol
-      * [ ] Every file under src/dependencies, if present
+      * [ ] `src/DssSpell.sol`
+      * [ ] Every file under `src/dependencies`, if present
       * [ ] No other files are included
     * [ ] Select the correct Pull Request
     * [ ] Run "PR-only" PR analysis mode

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -297,7 +297,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Ensure no filters are applied to the analysis results
   * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
     * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
-    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> `Save` overwrite -> rerun the analysis (In case, this action is blocked due to lack of authority, raise it to spell group)
+    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> `Save` -> rerun the analysis (In case, this action is blocked due to lack of authority, raise it to spell group)
   * [ ] Thoroughly inspect the analysis "Settings" for signs of manipulation
     * [ ] "Project Name" and "Repository Name" are correctly set
     * [ ] "Branch Name" is set to "master"

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -234,7 +234,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
     * [ ] "SCOPE" for "current analysis" is set to `Targeted review`
     * [ ] "SCOPE" for "current analysis" only includes:
-      * [ ]`src/DssSpell.sol`
+      * [ ] `src/DssSpell.sol`
       * [ ] IF `src/dependencies` is present in spell repo, ensure all files in the dependencies folder are included
     * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
   * [ ] Once Octane analysis is finished on the latest commit, review every finding and use "Acknowledge finding" to select the applicable classification and provide the reasoning

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -202,13 +202,13 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Exec hash is correct (use `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"` where `wget` doesn't work)
   * [ ] Ensure `description` date in `DssSpell.sol` matches target date inside Exec Doc
 * Octane Review
-  * [ ] Find the most recent `Sky Ecosystem: Spells mainnet` Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
-  * [ ] IF no Octane analysis exists on the latest commit for `Sky Ecosystem: Spells mainnet`, trigger a new analysis (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
+  * [ ] Find the most recent "Sky Ecosystem: Spells mainnet" Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
+  * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", trigger a new analysis (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
   * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] Check every finding and leave `feedback` per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details => Press "Leave feedback" => Write comment => Press "Share feedback")
-    * [ ] All findings either have your `feedback` or are already resolved
+  * [ ] Check every finding and leave feedback per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details => Press "Leave feedback" => Write comment => Press "Share feedback")
+    * [ ] All findings either have your feedback or are already resolved
     * [ ] IF any blocking issue was found, raise it to the current spell signal group
   * [ ] IF there is any findings that were resolved in the PR, the findings can be marked resolved. (Press "Finding Acknowledged" on the right-upper side of Finding details -> Select "Resolved" -> Leave comment "The finding was addressed from [commit](link)" => Press "Acknowledge")
 * [ ] Make sure all review comments are either addressed or explicitly answered

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -284,10 +284,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Octane Review
   * [ ] Find the most recent "Sky Ecosystem: Spells mainnet" Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
   * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", trigger a new analysis
-    * [ ] Ensure the "SCOPE" for "project" is standardized to include:
+    * [ ] Ensure the project scope is standardized to only include:
       * [ ] `src/DssSpell.sol`
-      * [ ] Every file under `src/dependencies`, if present
-      * [ ] No other files are included
+      * [ ] IF `src/dependencies` present, every file under the directory
     * [ ] Select the correct Pull Request
     * [ ] Run "PR-only" PR analysis mode
   * [ ] Use the most recent analysis for the review
@@ -298,21 +297,18 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Ensure no filters are applied to the analysis results
   * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
     * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
-    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> "Save overrides" and rerun the analysis (In case, this action is blocked due to lack of authority, raise it to spell group)
-  * [ ] Thoroughly inspect the analysis "Settings" tab for signs of manipulation
+    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> `Save` overwrite -> rerun the analysis (In case, this action is blocked due to lack of authority, raise it to spell group)
+  * [ ] Thoroughly inspect the analysis "Settings" for signs of manipulation
     * [ ] "Project Name" and "Repository Name" are correctly set
     * [ ] "Branch Name" is set to "master"
     * [ ] "Install dependencies" is enabled
-    * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
-  * [ ] Thoroughly inspect the analysis "Scope" tab for signs of manipulation
+  * [ ] Thoroughly inspect the analysis "Scope" for signs of manipulation
     * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
-    * [ ] "SCOPE" for "current analysis" is set to `Targeted review`
-    * [ ] "SCOPE" for "current analysis" only includes:
+    * [ ] Scope of the current analysis is set to `Targeted review` and only includes:
       * [ ] `src/DssSpell.sol`
-      * [ ] IF `src/dependencies` is present in spell repo, ensure all files in the dependencies folder are included
-    * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
-  * [ ] Once Octane analysis is finished on the latest commit, review every finding and use "Acknowledge finding" to select the applicable classification and provide the reasoning
-    * [ ] All findings either have an acknowledgement classification and reasoning or are already resolved
+      * [ ] IF `src/dependencies` present, every file under the directory
+  * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
+  * [ ] Once Octane analysis is finished on the latest commit, review every finding and either resolve it or mark it as acknowledged with a classification and reasoning
     * [ ] IF any blocking issue was found, raise it to the current spell signal group
     * [ ] IF any findings were addressed in the PR, the commit of the change should be added in the comment
   * [ ] Notify reviewers once the final analysis review is complete by providing the vulnerabilities-view URL using:

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -203,14 +203,28 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Ensure `description` date in `DssSpell.sol` matches target date inside Exec Doc
 * Octane Review
   * [ ] Find the most recent "Sky Ecosystem: Spells mainnet" Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
-  * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", trigger a new analysis (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
-  * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
-  * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
-  * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] Once Octane analysis is finished on the latest commit, review every finding and leave feedback per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details -> Press "Leave feedback" -> Write comment -> Press "Share feedback")
+  * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", trigger a new analysis
+    * [ ] Select the correct Pull Request
+    * [ ] Run "PR-only" PR analysis mode
+  * [ ] Ensure no filters are applied to the analysis results
+  * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
+    * [ ] IF any contract shows "Source unverified", investigate the address (eg. the source cannot be verified as the address is an EOA)
+    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> "Save overrides" and rerun the analysis (In case, this action is blocked due to lack of authority, raise it to spell group)
+  * [ ] Thoroughly inspect the analysis "Settings" tab for signs of manipulation
+    * [ ] "Project Name" and "Repository Name" are correctly set
+    * [ ] "Branch Name" is set to "master"
+    * [ ] "Install dependencies" is enabled
+    * [ ] Raise to spell group IF any malicious or unexpected setting is found including all setup that is not listed above
+  * [ ] Thoroughly inspect the analysis "Scope" tab for signs of manipulation
+    * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
+    * [ ] "SCOPE" includes:
+      * [ ] "src/DssSpell.sol"
+      * [ ] IF "src/dependencies" is present, ensure all files in the dependencies folder are included
+    * [ ] Raise to spell group IF any malicious or unexpected setting is found including all setup that is not listed above
+  * [ ] Once Octane analysis is finished on the latest commit, review every finding and leave "Feedback" per finding whether it matter or not, and the reasoning
     * [ ] All findings either have your feedback or are already resolved
     * [ ] IF any blocking issue was found, raise it to the current spell signal group
-  * [ ] IF there are any findings that were resolved in the PR, they can be marked resolved. (Press "Finding Acknowledged" on the upper-right corner of the Finding details panel -> Select "Resolved" -> Leave comment "The finding was addressed from [commit](link)" -> Press "Acknowledge")
+    * [ ] IF any findings were addressed in the PR, the commit of the change should be added in the comment
   * [ ] Notify reviewers once you finish the review of the recent analysis
 * [ ] Make sure all review comments are either addressed or explicitly answered
 * [ ] Make sure all items in the Exec Sheet are confirmed, OTHERWISE notify Responsible Governance Facilitator

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -309,9 +309,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * [ ] `src/DssSpell.sol`
       * [ ] IF `src/dependencies` is present, every file under the directory
       * [ ] No other files are included
-  * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
+  * [ ] IF any malicious or unexpected setting is found, including any configuration not listed above, address it, re-run the analysis, and redo the "Octane Review" section
+    * [ ] IF it cannot be addressed, raise it to the current spell group
   * [ ] Once Octane analysis is finished on the latest commit, review every finding and either resolve it or mark it as acknowledged with a classification and reasoning
-    * [ ] IF any blocking issue was found, raise it to the current spell signal group
+    * [ ] IF any blocking issue was found, raise it to the current spell group
     * [ ] IF any findings were addressed in the PR, the commit of the change should be added in the comment
   * [ ] Notify reviewers once the final analysis review is complete by providing the vulnerabilities-view URL using:
   `https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/<ANALYSIS_NUMBER>/vulnerabilities?visibility=ALL`

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -287,6 +287,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Ensure the project scope is standardized to only include:
       * [ ] `src/DssSpell.sol`
       * [ ] IF `src/dependencies` present, every file under the directory
+      * [ ] No other files are included
     * [ ] Select the correct Pull Request
     * [ ] Run "PR-only" PR analysis mode
   * [ ] Use the most recent analysis for the review
@@ -297,7 +298,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Ensure no filters are applied to the analysis results
   * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
     * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
-    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> `Save` -> rerun the analysis (In case, this action is blocked due to lack of authority, raise it to spell group)
+    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> "Save" -> rerun the analysis 
   * [ ] Thoroughly inspect the analysis "Settings" for signs of manipulation
     * [ ] "Project Name" and "Repository Name" are correctly set
     * [ ] "Branch Name" is set to "master"
@@ -307,6 +308,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Scope of the current analysis is set to `Targeted review` and only includes:
       * [ ] `src/DssSpell.sol`
       * [ ] IF `src/dependencies` present, every file under the directory
+      * [ ] No other files are included
   * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
   * [ ] Once Octane analysis is finished on the latest commit, review every finding and either resolve it or mark it as acknowledged with a classification and reasoning
     * [ ] IF any blocking issue was found, raise it to the current spell signal group

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -207,7 +207,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
   * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] Check every finding and leave feedback per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details => Press "Leave feedback" => Write comment => Press "Share feedback")
+  * [ ] Once Octane analysis is finished on the latest commit, check every finding and leave feedback per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details => Press "Leave feedback" => Write comment => Press "Share feedback")
     * [ ] All findings either have your feedback or are already resolved
     * [ ] IF any blocking issue was found, raise it to the current spell signal group
   * [ ] IF there is any findings that were resolved in the PR, the findings can be marked resolved. (Press "Finding Acknowledged" on the right-upper side of Finding details -> Select "Resolved" -> Leave comment "The finding was addressed from [commit](link)" => Press "Acknowledge")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -318,6 +318,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * [ ] Make sure all review comments are either addressed or explicitly answered
 * [ ] Make sure all items in the Exec Sheet are confirmed, OTHERWISE notify Responsible Governance Facilitator
 * [ ] Notify the reviewers (e.g. "Exec Hash is added, reviews are addressed")
+* [ ] IF there is new commit with spell code update, redo the "Octane Review" section above
 
 ## Deployment Stage
 

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -208,7 +208,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Run "PR-only" PR analysis mode
   * [ ] Ensure no filters are applied to the analysis results
   * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
-    * [ ] IF any contract shows "Source unverified", investigate the address (eg. the source cannot be verified as the address is an EOA)
+    * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
     * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> "Save overrides" and rerun the analysis (In case, this action is blocked due to lack of authority, raise it to spell group)
   * [ ] Thoroughly inspect the analysis "Settings" tab for signs of manipulation
     * [ ] "Project Name" and "Repository Name" are correctly set
@@ -218,8 +218,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Thoroughly inspect the analysis "Scope" tab for signs of manipulation
     * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
     * [ ] "SCOPE" includes:
-      * [ ] "src/DssSpell.sol"
-      * [ ] IF "src/dependencies" is present, ensure all files in the dependencies folder are included
+      * [ ] `src/DssSpell.sol`
+      * [ ] IF `src/dependencies` is present, ensure all files in the dependencies folder are included
     * [ ] Raise to spell group IF any malicious or unexpected setting is found including all setup that is not listed above
   * [ ] Once Octane analysis is finished on the latest commit, review every finding and leave "Feedback" per finding whether it matter or not, and the reasoning
     * [ ] All findings either have your feedback or are already resolved

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -202,16 +202,15 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Exec hash is correct (use `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"` where `wget` doesn't work)
   * [ ] Ensure `description` date in `DssSpell.sol` matches target date inside Exec Doc
 * Octane Review
-  * [ ] IF no Octane analysis exists on the latest commit from [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23), trigger a new one (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
+  * [ ] Find the most recent `Sky Ecosystem: Spells mainnet` Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
+  * [ ] IF no Octane analysis exists on the latest commit for `Sky Ecosystem: Spells mainnet`, trigger a new analysis (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
   * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] List every reported vulnerability and warning (split into separate items when one finding contains multiple different issues):
-    1. Title [Octane URL]
-      * Link to the relevant code block: [GitHub permalink]
-      * Is this issue blocking spell deployment?
-      * Required reason (explain why it can be a problem or can't be):
-  * [ ] IF any blocking issue is found, raise it to the current spell signal group
+  * [ ] Check every finding and leave `feedback` per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details => Press "Leave feedback" => Write comment => Press "Share feedback")
+    * [ ] All findings either have your `feedback` or are already resolved
+    * [ ] IF any blocking issue was found, raise it to the current spell signal group
+  * [ ] IF there is any findings that were resolved in the PR, the findings can be marked resolved. (Press "Finding Acknowledged" on the right-upper side of Finding details -> Select "Resolved" -> Leave comment "The finding was addressed from [commit](link)" => Press "Acknowledge")
 * [ ] Make sure all review comments are either addressed or explicitly answered
 * [ ] Make sure all items in the Exec Sheet are confirmed, OTHERWISE notify Responsible Governance Facilitator
 * [ ] Notify the reviewers (e.g. "Exec Hash is added, reviews are addressed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -207,10 +207,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
   * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] Once Octane analysis is finished on the latest commit, check every finding and leave feedback per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details => Press "Leave feedback" => Write comment => Press "Share feedback")
+  * [ ] Once Octane analysis is finished on the latest commit, review every finding and leave feedback per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details -> Press "Leave feedback" -> Write comment -> Press "Share feedback")
     * [ ] All findings either have your feedback or are already resolved
     * [ ] IF any blocking issue was found, raise it to the current spell signal group
-  * [ ] IF there is any findings that were resolved in the PR, the findings can be marked resolved. (Press "Finding Acknowledged" on the right-upper side of Finding details -> Select "Resolved" -> Leave comment "The finding was addressed from [commit](link)" => Press "Acknowledge")
+  * [ ] IF there are any findings that were resolved in the PR, they can be marked resolved. (Press "Finding Acknowledged" on the upper-right corner of the Finding details panel -> Select "Resolved" -> Leave comment "The finding was addressed from [commit](link)" -> Press "Acknowledge")
+  * [ ] Notify reviewers once you finish the review of the recent analysis
 * [ ] Make sure all review comments are either addressed or explicitly answered
 * [ ] Make sure all items in the Exec Sheet are confirmed, OTHERWISE notify Responsible Governance Facilitator
 * [ ] Notify the reviewers (e.g. "Exec Hash is added, reviews are addressed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -210,8 +210,17 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 * Octane Review
   * [ ] Find the most recent "Sky Ecosystem: Spells mainnet" Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
   * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", trigger a new analysis
+    * [ ] Ensure the "SCOPE" for "project" is standardized to include:
+      * [ ] src/DssSpell.sol
+      * [ ] Every file under src/dependencies, if present
+      * [ ] No other files are included
     * [ ] Select the correct Pull Request
     * [ ] Run "PR-only" PR analysis mode
+  * [ ] Use the most recent analysis for the review
+    ```
+    Analysis number: _Insert analysis number used_ 
+    Commit hash analysis ran against: _Insert commit hash used for analysis_ 
+    ```
   * [ ] Ensure no filters are applied to the analysis results
   * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
     * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
@@ -220,18 +229,20 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] "Project Name" and "Repository Name" are correctly set
     * [ ] "Branch Name" is set to "master"
     * [ ] "Install dependencies" is enabled
-    * [ ] Raise to spell group IF any malicious or unexpected setting is found including all setup that is not listed above
+    * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
   * [ ] Thoroughly inspect the analysis "Scope" tab for signs of manipulation
     * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
-    * [ ] "SCOPE" includes:
-      * [ ] `src/DssSpell.sol`
-      * [ ] IF `src/dependencies` is present, ensure all files in the dependencies folder are included
-    * [ ] Raise to spell group IF any malicious or unexpected setting is found including all setup that is not listed above
-  * [ ] Once Octane analysis is finished on the latest commit, review every finding and leave "Feedback" per finding whether it matter or not, and the reasoning
-    * [ ] All findings either have your feedback or are already resolved
+    * [ ] "SCOPE" for "current analysis" is set to `Targeted review`
+    * [ ] "SCOPE" for "current analysis" only includes:
+      * [ ]`src/DssSpell.sol`
+      * [ ] IF `src/dependencies` is present in spell repo, ensure all files in the dependencies folder are included
+    * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
+  * [ ] Once Octane analysis is finished on the latest commit, review every finding and use "Acknowledge finding" to select the applicable classification and provide the reasoning
+    * [ ] All findings either have an acknowledgement classification and reasoning or are already resolved
     * [ ] IF any blocking issue was found, raise it to the current spell signal group
     * [ ] IF any findings were addressed in the PR, the commit of the change should be added in the comment
-  * [ ] Notify reviewers once you finish the review of the recent analysis
+  * [ ] Notify reviewers once the final analysis review is complete by providing the vulnerabilities-view URL using:
+  `https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/<ANALYSIS_NUMBER>/vulnerabilities?visibility=ALL`
 * [ ] Make sure all review comments are either addressed or explicitly answered
 * [ ] Make sure all items in the Exec Sheet are confirmed, OTHERWISE notify Responsible Governance Facilitator
 * [ ] Notify the reviewers (e.g. "Exec Hash is added, reviews are addressed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -286,7 +286,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", trigger a new analysis
     * [ ] Ensure the project scope is standardized to only include:
       * [ ] `src/DssSpell.sol`
-      * [ ] IF `src/dependencies` present, every file under the directory
+      * [ ] IF `src/dependencies` is present, every file under the directory
       * [ ] No other files are included
     * [ ] Select the correct Pull Request
     * [ ] Run "PR-only" PR analysis mode
@@ -298,16 +298,16 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Ensure no filters are applied to the analysis results
   * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
     * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
-    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> "Save" -> rerun the analysis 
-  * [ ] Thoroughly inspect the analysis "Settings" for signs of manipulation
-    * [ ] "Project Name" and "Repository Name" are correctly set
-    * [ ] "Branch Name" is set to "master"
-    * [ ] "Install dependencies" is enabled
-  * [ ] Thoroughly inspect the analysis "Scope" for signs of manipulation
-    * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
+    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> save -> rerun the analysis 
+  * [ ] Thoroughly inspect the analysis settings for signs of manipulation
+    * [ ] Project name and repository name are correctly set
+    * [ ] Branch name is set to "master"
+    * [ ] Dependency installation is enabled
+  * [ ] Thoroughly inspect the analysis scope for signs of manipulation
+    * [ ] Project type, target, languages are correctly set as "Smart Contracts" and "Solidity"
     * [ ] Scope of the current analysis is set to `Targeted review` and only includes:
       * [ ] `src/DssSpell.sol`
-      * [ ] IF `src/dependencies` present, every file under the directory
+      * [ ] IF `src/dependencies` is present, every file under the directory
       * [ ] No other files are included
   * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
   * [ ] Once Octane analysis is finished on the latest commit, review every finding and either resolve it or mark it as acknowledged with a classification and reasoning

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -296,9 +296,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     Commit hash analysis ran against: _Insert commit hash used for analysis_ 
     ```
   * [ ] Ensure no filters are applied to the analysis results
-  * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
-    * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
-    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> save -> rerun the analysis 
+  * [ ] Ensure every contract listed in on-chain dependencies has its source and ABI fetched from the correct chain
+    * [ ] IF any contract has an unverified source, investigate the address (e.g. the source cannot be verified as the address is an EOA)
+    * [ ] IF any contract has its source skipped or its selected chain does not match the chain it is deployed on, select the correct chain for each contract -> save -> rerun the analysis
   * [ ] Thoroughly inspect the analysis settings for signs of manipulation
     * [ ] Project name and repository name are correctly set
     * [ ] Branch name is set to "master"

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -383,6 +383,7 @@ _Insert your local test logs here_
 * Octane Review
   * [ ] IF no Octane analysis exists on the latest commit from [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23), trigger a new one (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
+  * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
   * [ ] List every reported vulnerability and warning (split into separate items when one finding contains multiple different issues):
     1. Title [Octane URL]

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -380,11 +380,22 @@ _Insert your local test logs here_
   * [ ] Exec Doc URL in the spell comment refers to the [https://github.com/sky-ecosystem/executive-votes](https://github.com/sky-ecosystem/executive-votes) repository
   * [ ] Every action present in the spell code is present in the Exec Doc
   * [ ] Every action in the Exec Doc is present in the spell code
+* Octane Review
+  * [ ] Check if there is an existing Octane analysis on the latest commit on [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23) 
+    * [ ] OTHERWISE, trigger new analysis by pressing "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis"
+    * [ ] List every identified issues (split issues into multiple ones when one issue actually contains multiple issues):
+      1. Issue title [Octane URL]
+        * Link to the relevant code block: [GitHub link or file]
+        * Is this issue blocking spell deployment?
+        * Reason:
+    * [ ] IF any blocking issue is found, raise it to spell channel
 * IF new commits are present in the spell
   * [ ] Copy relevant checklist items from the above and redo them
   * [ ] Ensure newly added code is covered by tests
   * [ ] Check if chainlog needs to be updated
   * [ ] Copy over and redo "Tests" section from the above
+  * [ ] IF actual spell action code has been updated
+    * [ ] Copy over and redo "Octane Review" section from the above
 * [ ] IF all checks pass, make sure to include explicit "Good to deploy" comment
 
 ## Deployed Stage

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -383,12 +383,12 @@ _Insert your local test logs here_
 * Octane Review
   * [ ] Check if there is an existing Octane analysis on the latest commit on [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23) 
     * [ ] OTHERWISE, trigger new analysis by pressing "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis"
-    * [ ] List every identified issues (split issues into multiple ones when one issue actually contains multiple issues):
-      1. Issue title [Octane URL]
-        * Link to the relevant code block: [GitHub link or file]
+    * [ ] List every reported findings (split into separate items when one findings contains multiple issues):
+      1. Title [Octane URL]
+        * Link to the relevant code block: [GitHub permalink]
         * Is this issue blocking spell deployment?
         * Reason:
-    * [ ] IF any blocking issue is found, raise it to spell channel
+    * [ ] IF any blocking issue is found, raise it to the current spell signal group
 * IF new commits are present in the spell
   * [ ] Copy relevant checklist items from the above and redo them
   * [ ] Ensure newly added code is covered by tests

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -381,21 +381,21 @@ _Insert your local test logs here_
   * [ ] Every action present in the spell code is present in the Exec Doc
   * [ ] Every action in the Exec Doc is present in the spell code
 * Octane Review
-  * [ ] Check if there is an existing Octane analysis on the latest commit on [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23) 
-    * [ ] OTHERWISE, trigger new analysis by pressing "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis"
-    * [ ] List every reported findings (split into separate items when one findings contains multiple issues):
-      1. Title [Octane URL]
-        * Link to the relevant code block: [GitHub permalink]
-        * Is this issue blocking spell deployment?
-        * Reason:
-    * [ ] IF any blocking issue is found, raise it to the current spell signal group
+  * [ ] IF no Octane analysis exists on the latest commit from [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23), trigger a new one (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
+  * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
+  * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
+  * [ ] List every reported vulnerability and warning (split into separate items when one finding contains multiple different issues):
+    1. Title [Octane URL]
+      * Link to the relevant code block: [GitHub permalink]
+      * Is this issue blocking spell deployment?
+      * Required reason (explain why it can be a problem or can't be):
+  * [ ] IF any blocking issue is found, raise it to the current spell signal group
 * IF new commits are present in the spell
   * [ ] Copy relevant checklist items from the above and redo them
   * [ ] Ensure newly added code is covered by tests
   * [ ] Check if chainlog needs to be updated
   * [ ] Copy over and redo "Tests" section from the above
-  * [ ] IF actual spell action code has been updated
-    * [ ] Copy over and redo "Octane Review" section from the above
+  * [ ] IF the spell code has been updated, redo the "Octane Review" section from above
 * [ ] IF all checks pass, make sure to include explicit "Good to deploy" comment
 
 ## Deployed Stage

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -387,7 +387,7 @@ _Insert your local test logs here_
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
   * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] Once Octane analysis is finished on the latest commit, check every finding and ensure the crafter left feedback on each finding specifying whether the finding matters or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details)
+  * [ ] Once the crafter has finished reviewing the most recent analysis, check every finding and ensure the crafter left feedback on each finding specifying whether the finding matters or not, and the reasoning. (Press "Feedback" on the upper-right corner of the Finding details panel)
     * [ ] All findings either have crafter's feedback or are already resolved ELSE notify the crafter
     * [ ] Ensure the crafter's feedback comments are correct, ELSE raise it to the signal group
 * IF new commits are present in the spell

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -477,21 +477,19 @@ _Insert your local test logs here_
   * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
     * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
     * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, notify spell crafter
-  * [ ] Thoroughly inspect the analysis "Settings" tab for signs of manipulation
+  * [ ] Thoroughly inspect the analysis "Settings" for signs of manipulation
     * [ ] "Project Name" and "Repository Name" are correctly set
     * [ ] "Branch Name" is set to "master"
     * [ ] "Install dependencies" is enabled
-    * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
-  * [ ] Thoroughly inspect the analysis "Scope" tab for signs of manipulation
+  * [ ] Thoroughly inspect the analysis "Scope" for signs of manipulation
     * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
-    * [ ] "SCOPE" for "current analysis" is set to `Targeted review`
-    * [ ] "SCOPE" for "current analysis" only includes:
+    * [ ] Scope of the current analysis is set to `Targeted review` and includes only:
       * [ ] `src/DssSpell.sol`
-      * [ ] IF `src/dependencies` is present in spell repo, ensure all files in the dependencies folder are included
-    * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
-  * [ ] Once the crafter has finished reviewing the most recent analysis, check every finding and ensure the crafter left "Acknowledge finding" on each one specifying whether the finding matters or not, and the reasoning.
-    * [ ] All findings marked with "Finding Acknowledged" and have crafter's "Feedback" ELSE notify the crafter
-    * [ ] Ensure the crafter's "Feedback" comments are reasonable, ELSE raise it to the signal group
+      * [ ] IF `src/dependencies` present, every file under the directory
+  * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, address and re-run the analysis
+    * [ ] IF addressing is not possible, raise it to spell group
+  * [ ] Once the crafter has finished reviewing the most recent analysis, ensure every finding is resolved or acknowledged with the crafter's reasoning, ELSE notify the crafter
+    * [ ] Ensure the crafter's reasoning explains why the finding does or does not matter, ELSE raise it to the signal group
 * [ ] The commit reviewed in this checklist matches the latest commit in the spell PR
   _Insert latest reviewed commit hash_
 * IF new commits are present after the previous review

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -386,9 +386,9 @@ _Insert your local test logs here_
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
   * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] Check every finding and ensure the crafter left feedback on each findings specifying whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details)
-    * [ ] All findings either have crafter's feedback or are already resolved
-    * [ ] Ensure the crafter's feedback comments are correct, ELSE raise it to signal group
+  * [ ] Check every finding and ensure the crafter left feedback on each finding specifying whether the finding matters or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details)
+    * [ ] All findings either have crafter's feedback or are already resolved ELSE notify the crafter
+    * [ ] Ensure the crafter's feedback comments are correct, ELSE raise it to the signal group
 * IF new commits are present in the spell
   * [ ] Copy relevant checklist items from the above and redo them
   * [ ] Ensure newly added code is covered by tests

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -386,9 +386,9 @@ _Insert your local test logs here_
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
   * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] Check every finding and leave feedback per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details => Press "Leave feedback" => Write comment => Press "Share feedback")
-    * [ ] All findings either have your feedback or are already resolved
-    * [ ] IF any blocking issue was found, raise it to the current spell signal group
+  * [ ] Check every finding and ensure the crafter left feedback on each findings specifying whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details)
+    * [ ] All findings either have crafter's feedback or are already resolved
+    * [ ] Ensure the crafter's feedback comments are correct, ELSE raise it to signal group
 * IF new commits are present in the spell
   * [ ] Copy relevant checklist items from the above and redo them
   * [ ] Ensure newly added code is covered by tests

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -381,16 +381,14 @@ _Insert your local test logs here_
   * [ ] Every action present in the spell code is present in the Exec Doc
   * [ ] Every action in the Exec Doc is present in the spell code
 * Octane Review
-  * [ ] IF no Octane analysis exists on the latest commit from [Sky Ecosystem: Spells mainnet](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23), trigger a new one (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
+  * [ ] Find the most recent `Sky Ecosystem: Spells mainnet` Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
+  * [ ] IF no Octane analysis exists on the latest commit for `Sky Ecosystem: Spells mainnet`, trigger a new analysis (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
   * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] List every reported vulnerability and warning (split into separate items when one finding contains multiple different issues):
-    1. Title [Octane URL]
-      * Link to the relevant code block: [GitHub permalink]
-      * Is this issue blocking spell deployment?
-      * Required reason (explain why it can be a problem or can't be):
-  * [ ] IF any blocking issue is found, raise it to the current spell signal group
+  * [ ] Check every finding and leave `feedback` per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details => Press "Leave feedback" => Write comment => Press "Share feedback")
+    * [ ] All findings either have your `feedback` or are already resolved
+    * [ ] IF any blocking issue was found, raise it to the current spell signal group
 * IF new commits are present in the spell
   * [ ] Copy relevant checklist items from the above and redo them
   * [ ] Ensure newly added code is covered by tests

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -386,7 +386,7 @@ _Insert your local test logs here_
     * [ ] Wait until Octane analysis is triggered by crafter
   * [ ] Ensure no filters are applied to the analysis results
   * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
-    * [ ] IF any contract shows "Source unverified", investigate the address (eg. the source cannot be verified as the address is an EOA)
+    * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
     * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, notify spell crafter
   * [ ] Thoroughly inspect the analysis "Settings" tab for signs of manipulation
     * [ ] "Project Name" and "Repository Name" are correctly set
@@ -396,8 +396,8 @@ _Insert your local test logs here_
   * [ ] Thoroughly inspect the analysis "Scope" tab for signs of manipulation
     * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
     * [ ] "SCOPE" includes:
-      * [ ] "src/DssSpell.sol"
-      * [ ] IF "src/dependencies" is present, ensure all files in the dependencies folder are included
+      * [ ] `src/DssSpell.sol`
+      * [ ] IF `src/dependencies` is present, ensure all files in the dependencies folder are included
     * [ ] Raise to spell group IF any malicious or unexpected setting is found including all setup that is not listed above
   * [ ] Once the crafter has finished reviewing the most recent analysis, check every finding and ensure the crafter left "Feedback" on each finding specifying whether the finding matters or not, and the reasoning.
     * [ ] All findings either have crafter's "Feedback" or are already resolved ELSE notify the crafter

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -490,7 +490,7 @@ _Insert your local test logs here_
   * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, address and re-run the analysis
     * [ ] IF addressing is not possible, raise it to spell group
   * [ ] Once the crafter has finished reviewing the most recent analysis, ensure every finding is resolved or acknowledged with the crafter's reasoning, ELSE notify the crafter
-    * [ ] Ensure the crafter's reasoning explains why the finding does or does not matter, ELSE raise it to the signal group
+    * [ ] Ensure the crafter's reasoning explains why the finding does or does not matter, ELSE raise it to spell group
 * [ ] The commit reviewed in this checklist matches the latest commit in the spell PR
   _Insert latest reviewed commit hash_
 * IF new commits are present after the previous review

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -477,17 +477,17 @@ _Insert your local test logs here_
   * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
     * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
     * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, notify spell crafter
-  * [ ] Thoroughly inspect the analysis "Settings" for signs of manipulation
-    * [ ] "Project Name" and "Repository Name" are correctly set
-    * [ ] "Branch Name" is set to "master"
-    * [ ] "Install dependencies" is enabled
-  * [ ] Thoroughly inspect the analysis "Scope" for signs of manipulation
-    * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
+  * [ ] Thoroughly inspect the analysis settings for signs of manipulation
+    * [ ] Project name and repository name are correctly set
+    * [ ] Branch name is set to "master"
+    * [ ] Dependency installation is enabled
+  * [ ] Thoroughly inspect the analysis scope for signs of manipulation
+    * [ ] Project type, target, languages are correctly set as "Smart Contracts" and "Solidity"
     * [ ] Scope of the current analysis is set to `Targeted review` and only includes:
       * [ ] `src/DssSpell.sol`
-      * [ ] IF `src/dependencies` present, every file under the directory
+      * [ ] IF `src/dependencies` is present, every file under the directory
       * [ ] No other files are included
-  * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, address and re-run the analysis
+  * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
     * [ ] IF addressing is not possible, raise it to spell group
   * [ ] Once the crafter has finished reviewing the most recent analysis, ensure every finding is resolved or acknowledged with the crafter's reasoning, ELSE notify the crafter
     * [ ] Ensure the crafter's reasoning explains why the finding does or does not matter, ELSE raise it to spell group

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -381,13 +381,13 @@ _Insert your local test logs here_
   * [ ] Every action present in the spell code is present in the Exec Doc
   * [ ] Every action in the Exec Doc is present in the spell code
 * Octane Review
-  * [ ] Find the most recent `Sky Ecosystem: Spells mainnet` Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
-  * [ ] IF no Octane analysis exists on the latest commit for `Sky Ecosystem: Spells mainnet`, trigger a new analysis (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
+  * [ ] Find the most recent "Sky Ecosystem: Spells mainnet" Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
+  * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", trigger a new analysis (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
   * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] Check every finding and leave `feedback` per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details => Press "Leave feedback" => Write comment => Press "Share feedback")
-    * [ ] All findings either have your `feedback` or are already resolved
+  * [ ] Check every finding and leave feedback per finding whether the findings matter or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details => Press "Leave feedback" => Write comment => Press "Share feedback")
+    * [ ] All findings either have your feedback or are already resolved
     * [ ] IF any blocking issue was found, raise it to the current spell signal group
 * IF new commits are present in the spell
   * [ ] Copy relevant checklist items from the above and redo them

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -483,9 +483,10 @@ _Insert your local test logs here_
     * [ ] "Install dependencies" is enabled
   * [ ] Thoroughly inspect the analysis "Scope" for signs of manipulation
     * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
-    * [ ] Scope of the current analysis is set to `Targeted review` and includes only:
+    * [ ] Scope of the current analysis is set to `Targeted review` and only includes:
       * [ ] `src/DssSpell.sol`
       * [ ] IF `src/dependencies` present, every file under the directory
+      * [ ] No other files are included
   * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, address and re-run the analysis
     * [ ] IF addressing is not possible, raise it to spell group
   * [ ] Once the crafter has finished reviewing the most recent analysis, ensure every finding is resolved or acknowledged with the crafter's reasoning, ELSE notify the crafter

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -488,7 +488,6 @@ _Insert your local test logs here_
       * [ ] IF `src/dependencies` is present, every file under the directory
       * [ ] No other files are included
   * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
-    * [ ] IF addressing is not possible, raise it to spell group
   * [ ] Once the crafter has finished reviewing the most recent analysis, ensure every finding is resolved or acknowledged with the crafter's reasoning, ELSE notify the crafter
     * [ ] Ensure the crafter's reasoning explains why the finding does or does not matter, ELSE raise it to spell group
 * [ ] The commit reviewed in this checklist matches the latest commit in the spell PR

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -384,12 +384,24 @@ _Insert your local test logs here_
   * [ ] Find the most recent "Sky Ecosystem: Spells mainnet" Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
   * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", notify spell crafter
     * [ ] Wait until Octane analysis is triggered by crafter
-  * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
-  * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
-  * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] Once the crafter has finished reviewing the most recent analysis, check every finding and ensure the crafter left feedback on each finding specifying whether the finding matters or not, and the reasoning. (Press "Feedback" on the upper-right corner of the Finding details panel)
-    * [ ] All findings either have crafter's feedback or are already resolved ELSE notify the crafter
-    * [ ] Ensure the crafter's feedback comments are correct, ELSE raise it to the signal group
+  * [ ] Ensure no filters are applied to the analysis results
+  * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
+    * [ ] IF any contract shows "Source unverified", investigate the address (eg. the source cannot be verified as the address is an EOA)
+    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, notify spell crafter
+  * [ ] Thoroughly inspect the analysis "Settings" tab for signs of manipulation
+    * [ ] "Project Name" and "Repository Name" are correctly set
+    * [ ] "Branch Name" is set to "master"
+    * [ ] "Install dependencies" is enabled
+    * [ ] Raise to spell group IF any malicious or unexpected setting is found including all setup that is not listed above
+  * [ ] Thoroughly inspect the analysis "Scope" tab for signs of manipulation
+    * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
+    * [ ] "SCOPE" includes:
+      * [ ] "src/DssSpell.sol"
+      * [ ] IF "src/dependencies" is present, ensure all files in the dependencies folder are included
+    * [ ] Raise to spell group IF any malicious or unexpected setting is found including all setup that is not listed above
+  * [ ] Once the crafter has finished reviewing the most recent analysis, check every finding and ensure the crafter left "Feedback" on each finding specifying whether the finding matters or not, and the reasoning.
+    * [ ] All findings either have crafter's "Feedback" or are already resolved ELSE notify the crafter
+    * [ ] Ensure the crafter's "Feedback" comments are correct, ELSE raise it to the signal group
 * IF new commits are present in the spell
   * [ ] Copy relevant checklist items from the above and redo them
   * [ ] Ensure newly added code is covered by tests

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -384,6 +384,11 @@ _Insert your local test logs here_
   * [ ] Find the most recent "Sky Ecosystem: Spells mainnet" Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
   * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", notify spell crafter
     * [ ] Wait until Octane analysis is triggered by crafter
+  * [ ] Use the most recent analysis for the review
+    ```
+    Analysis number: _Insert analysis number used_ 
+    Commit hash analysis ran against: _Insert commit hash used for analysis_ 
+    ```
   * [ ] Ensure no filters are applied to the analysis results
   * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
     * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
@@ -392,16 +397,17 @@ _Insert your local test logs here_
     * [ ] "Project Name" and "Repository Name" are correctly set
     * [ ] "Branch Name" is set to "master"
     * [ ] "Install dependencies" is enabled
-    * [ ] Raise to spell group IF any malicious or unexpected setting is found including all setup that is not listed above
+    * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
   * [ ] Thoroughly inspect the analysis "Scope" tab for signs of manipulation
     * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
-    * [ ] "SCOPE" includes:
-      * [ ] `src/DssSpell.sol`
-      * [ ] IF `src/dependencies` is present, ensure all files in the dependencies folder are included
-    * [ ] Raise to spell group IF any malicious or unexpected setting is found including all setup that is not listed above
-  * [ ] Once the crafter has finished reviewing the most recent analysis, check every finding and ensure the crafter left "Feedback" on each finding specifying whether the finding matters or not, and the reasoning.
-    * [ ] All findings either have crafter's "Feedback" or are already resolved ELSE notify the crafter
-    * [ ] Ensure the crafter's "Feedback" comments are correct, ELSE raise it to the signal group
+    * [ ] "SCOPE" for "current analysis" is set to `Targeted review`
+    * [ ] "SCOPE" for "current analysis" only includes:
+      * [ ]`src/DssSpell.sol`
+      * [ ] IF `src/dependencies` is present in spell repo, ensure all files in the dependencies folder are included
+    * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
+  * [ ] Once the crafter has finished reviewing the most recent analysis, check every finding and ensure the crafter left "Acknowledge finding" on each one specifying whether the finding matters or not, and the reasoning.
+    * [ ] All findings marked with "Finding Acknowledged" and have crafter's "Feedback" ELSE notify the crafter
+    * [ ] Ensure the crafter's "Feedback" comments are reasonable, ELSE raise it to the signal group
 * [ ] The commit reviewed in this checklist matches the latest commit in the spell PR
   _Insert latest reviewed commit hash_
 * IF new commits are present after the previous review

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -382,11 +382,12 @@ _Insert your local test logs here_
   * [ ] Every action in the Exec Doc is present in the spell code
 * Octane Review
   * [ ] Find the most recent "Sky Ecosystem: Spells mainnet" Octane analysis from [projects page](https://app.octane.security/projects) OR check report from [project link](https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/)
-  * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", trigger a new analysis (Press "Run new analysis" in the top right corner -> Select correct PR -> Select "PR-only" for the "PR analysis mode" field -> Click "Run analysis")
+  * [ ] IF no Octane analysis exists on the latest commit for "Sky Ecosystem: Spells mainnet", notify spell crafter
+    * [ ] Wait until Octane analysis is triggered by crafter
   * [ ] Ensure no filters are applied to the Octane results (press "All filters" -> set "All" for each filter group)
   * [ ] Ensure all onchain dependencies are correctly fetched (Click on the "On Chain dependencies" tab -> inspect "Contracts" table). In case "Source skipped" contracts are present, select correct chain for each contract -> "Save overrides" and rerun the analysis
   * [ ] Thoroughly inspect analysis settings for signs of manipulation (Click on the "Settings" tab -> check "Analysis Scope", "Install dependencies", and other relevant sections)
-  * [ ] Check every finding and ensure the crafter left feedback on each finding specifying whether the finding matters or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details)
+  * [ ] Once Octane analysis is finished on the latest commit, check every finding and ensure the crafter left feedback on each finding specifying whether the finding matters or not, and the reasoning. (Press "Feedback" on the right-upper side of Finding details)
     * [ ] All findings either have crafter's feedback or are already resolved ELSE notify the crafter
     * [ ] Ensure the crafter's feedback comments are correct, ELSE raise it to the signal group
 * IF new commits are present in the spell

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -402,7 +402,7 @@ _Insert your local test logs here_
     * [ ] "Project type", "Target", "Languages" are correctly set as "Smart Contracts" and "Solidity"
     * [ ] "SCOPE" for "current analysis" is set to `Targeted review`
     * [ ] "SCOPE" for "current analysis" only includes:
-      * [ ]`src/DssSpell.sol`
+      * [ ] `src/DssSpell.sol`
       * [ ] IF `src/dependencies` is present in spell repo, ensure all files in the dependencies folder are included
     * [ ] IF any malicious or unexpected setting is found including all setup that is not listed above, raise to spell group
   * [ ] Once the crafter has finished reviewing the most recent analysis, check every finding and ensure the crafter left "Acknowledge finding" on each one specifying whether the finding matters or not, and the reasoning.

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -474,9 +474,9 @@ _Insert your local test logs here_
     Commit hash analysis ran against: _Insert commit hash used for analysis_ 
     ```
   * [ ] Ensure no filters are applied to the analysis results
-  * [ ] By inspecting the "Contracts" table in the "On Chain dependencies" tab, ensure every contract has its source and ABI fetched from the correct chain
-    * [ ] IF any contract shows "Source unverified", investigate the address (e.g. the source cannot be verified as the address is an EOA)
-    * [ ] IF any contract shows "Source skipped" or its selected chain does not match the chain it is deployed on, notify spell crafter
+  * [ ] Ensure every contract listed in on-chain dependencies has its source and ABI fetched from the correct chain
+    * [ ] IF any contract has an unverified source, investigate the address (e.g. the source cannot be verified as the address is an EOA)
+    * [ ] IF any contract has its source skipped or its selected chain does not match the chain it is deployed on, notify spell crafter
   * [ ] Thoroughly inspect the analysis settings for signs of manipulation
     * [ ] Project name and repository name are correctly set
     * [ ] Branch name is set to "master"


### PR DESCRIPTION
This PR adds octane review item into the core spell checklist.

Relevant links:
- Octane review spell project: https://app.octane.security/projects/p/fa7414c7-d44a-4a2d-b767-2ed7462547a5/analysis/23

---

Here, instead of using [contract event listener](https://docs.ethers.org/v6/api/contract/#BaseContract-on); (added the loop with interval and then fetch logs. To avoid websocket disconnection, error handling)