### PR TITLE
fix: require autoline exec after parameter updates

### DIFF
--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -129,6 +129,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Additions are tested via `testAddedChainlogKeys`
     * [ ] Removals are tested via `testRemovedChainlogKeys`
   * [ ] Adjust system values, collateral values inside `config.sol`
+  * IF an ilk's `AutoLine` configuration is updated via `DssExecLib`
+    * [ ] Each [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L658) or [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L648) call is immediately followed by `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)`
+  * IF [`DssAutoLine.setIlk(ilk, line, gap, ttl)`](https://github.com/sky-ecosystem/dss-auto-line/blob/master/src/DssAutoLine.sol#L81-L85) is called directly instead of using a `DssExecLib` AutoLine setter
+    * [ ] The intended AutoLine configuration and live Vat debt-ceiling states are documented
   * [ ] Ensure every spell variable is declared as public/internal
   * Bug Bounty Registry Updates
     * [ ] Check that output of `make safeharbor-generate` matches the instructions provided by Governance Facilitators

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -131,8 +131,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Adjust system values, collateral values inside `config.sol`
   * IF an ilk's `AutoLine` configuration is updated via `DssExecLib`
     * [ ] Each [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/69b658f35d8618272cd139dfc18c5713caf6b96b/src/DssExecLib.sol#L665-L670) or [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/69b658f35d8618272cd139dfc18c5713caf6b96b/src/DssExecLib.sol#L655-L659) call is immediately followed by `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)`
-  * IF [`DssAutoLine.setIlk(ilk, line, gap, ttl)`](https://github.com/sky-ecosystem/dss-auto-line/blob/master/src/DssAutoLine.sol#L81-L85) is called directly instead of using a `DssExecLib` `AutoLine` setter
-    * [ ] The intended `AutoLine` configuration and live `Vat` debt-ceiling states are documented
+  * IF the Exec Sheet explicitly requires staged `AutoLine` configuration and live `Vat` debt-ceiling states
+    * [ ] `DssAutoLine.setIlk(ilk, line, gap, ttl)` is used directly instead of a `DssExecLib` `AutoLine` setter
+    * [ ] `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)` is called separately at each intended synchronization point
+    * [ ] The intended intermediate and final `AutoLine` configuration and live `Vat` debt-ceiling states are documented
   * [ ] Ensure every spell variable is declared as public/internal
   * Bug Bounty Registry Updates
     * [ ] Check that output of `make safeharbor-generate` matches the instructions provided by Governance Facilitators

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -130,7 +130,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] Removals are tested via `testRemovedChainlogKeys`
   * [ ] Adjust system values, collateral values inside `config.sol`
   * IF an ilk's `AutoLine` configuration is updated via `DssExecLib`
-    * [ ] Each [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L658) or [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L648) call is immediately followed by `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)`
+    * [ ] Each [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/69b658f35d8618272cd139dfc18c5713caf6b96b/src/DssExecLib.sol#L665-L670) or [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/69b658f35d8618272cd139dfc18c5713caf6b96b/src/DssExecLib.sol#L655-L659) call is immediately followed by `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)`
   * IF [`DssAutoLine.setIlk(ilk, line, gap, ttl)`](https://github.com/sky-ecosystem/dss-auto-line/blob/master/src/DssAutoLine.sol#L81-L85) is called directly instead of using a `DssExecLib` `AutoLine` setter
     * [ ] The intended `AutoLine` configuration and live `Vat` debt-ceiling states are documented
   * [ ] Ensure every spell variable is declared as public/internal

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -131,8 +131,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Adjust system values, collateral values inside `config.sol`
   * IF an ilk's `AutoLine` configuration is updated via `DssExecLib`
     * [ ] Each [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L658) or [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L648) call is immediately followed by `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)`
-  * IF [`DssAutoLine.setIlk(ilk, line, gap, ttl)`](https://github.com/sky-ecosystem/dss-auto-line/blob/master/src/DssAutoLine.sol#L81-L85) is called directly instead of using a `DssExecLib` AutoLine setter
-    * [ ] The intended AutoLine configuration and live Vat debt-ceiling states are documented
+  * IF [`DssAutoLine.setIlk(ilk, line, gap, ttl)`](https://github.com/sky-ecosystem/dss-auto-line/blob/master/src/DssAutoLine.sol#L81-L85) is called directly instead of using a `DssExecLib` `AutoLine` setter
+    * [ ] The intended `AutoLine` configuration and live `Vat` debt-ceiling states are documented
   * [ ] Ensure every spell variable is declared as public/internal
   * Bug Bounty Registry Updates
     * [ ] Check that output of `make safeharbor-generate` matches the instructions provided by Governance Facilitators

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -131,11 +131,15 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * [ ] The instruction to remove from AutoLine (`MCD_IAM_AUTO_LINE`) is present in the Exec Sheet
       * [ ] Collateral debt ceiling is set to `0` via [`DssExecLib.setIlkDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L611)
       * [ ] Global debt ceiling (`vat.Line`) is updated accordingly, UNLESS specifically instructed not to
-    * IF `AutoLine` parameters are updated
-      * [ ] EITHER is used, depending on the instruction:
-        * [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L658)
-        * [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L648)
-  * IF collateral debt ceiling (`vat.ilk.line`) is updated
+  * IF an ilk's `AutoLine` configuration is updated via `DssExecLib`
+    * [ ] EITHER is used, depending on the instruction:
+      * [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L658)
+      * [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L648)
+    * [ ] Each `DssExecLib` AutoLine setter call is immediately followed by `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)`
+    * [ ] AutoLine updates are tested by asserting the configured parameters and the exact resulting per-ilk and global Vat debt ceilings after cast
+  * IF [`DssAutoLine.setIlk(ilk, line, gap, ttl)`](https://github.com/sky-ecosystem/dss-auto-line/blob/master/src/DssAutoLine.sol#L81-L85) is called directly instead of using a `DssExecLib` AutoLine setter
+    * [ ] The intended AutoLine configuration and live Vat debt-ceiling states are documented and tested
+  * IF collateral debt ceiling (`vat.ilk.line`) is updated directly rather than through `AutoLine`
     * [ ] Collateral type (`ilk`) have [`AutoLine`](https://github.com/sky-ecosystem/dss-auto-line/tree/master) disabled previously or in the spell
     * [ ] EITHER is used, depending on the instruction:
         * [`DssExecLib.increaseIlkDebtCeiling(ilk, amount, global)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L621C14-L621C36)

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -137,8 +137,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/69b658f35d8618272cd139dfc18c5713caf6b96b/src/DssExecLib.sol#L655-L659)
     * [ ] Each `DssExecLib` `AutoLine` setter call is immediately followed by `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)`
     * [ ] `AutoLine` updates are tested by asserting the configured parameters and the exact resulting per-ilk and global `Vat` debt ceilings after cast
-  * IF [`DssAutoLine.setIlk(ilk, line, gap, ttl)`](https://github.com/sky-ecosystem/dss-auto-line/blob/master/src/DssAutoLine.sol#L81-L85) is called directly instead of using a `DssExecLib` AutoLine setter
-    * [ ] The intended `AutoLine` configuration and live `Vat` debt-ceiling states are documented and tested
+  * IF the Exec Sheet explicitly requires staged `AutoLine` configuration and live `Vat` debt-ceiling states
+    * [ ] `DssAutoLine.setIlk(ilk, line, gap, ttl)` is used directly instead of a `DssExecLib` `AutoLine` setter
+    * [ ] `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)` is called separately at each intended synchronization point
+    * [ ] Tests assert the intermediate and final `AutoLine` configuration and exact per-ilk and global `Vat` debt ceilings
   * IF collateral debt ceiling (`vat.ilk.line`) is updated directly rather than through `AutoLine`
     * [ ] Collateral type (`ilk`) have [`AutoLine`](https://github.com/sky-ecosystem/dss-auto-line/tree/master) disabled previously or in the spell
     * [ ] EITHER is used, depending on the instruction:

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -135,10 +135,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
     * [ ] EITHER is used, depending on the instruction:
       * [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L658)
       * [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L648)
-    * [ ] Each `DssExecLib` AutoLine setter call is immediately followed by `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)`
-    * [ ] AutoLine updates are tested by asserting the configured parameters and the exact resulting per-ilk and global Vat debt ceilings after cast
+    * [ ] Each `DssExecLib` `AutoLine` setter call is immediately followed by `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)`
+    * [ ] `AutoLine` updates are tested by asserting the configured parameters and the exact resulting per-ilk and global `Vat` debt ceilings after cast
   * IF [`DssAutoLine.setIlk(ilk, line, gap, ttl)`](https://github.com/sky-ecosystem/dss-auto-line/blob/master/src/DssAutoLine.sol#L81-L85) is called directly instead of using a `DssExecLib` AutoLine setter
-    * [ ] The intended AutoLine configuration and live Vat debt-ceiling states are documented and tested
+    * [ ] The intended `AutoLine` configuration and live `Vat` debt-ceiling states are documented and tested
   * IF collateral debt ceiling (`vat.ilk.line`) is updated directly rather than through `AutoLine`
     * [ ] Collateral type (`ilk`) have [`AutoLine`](https://github.com/sky-ecosystem/dss-auto-line/tree/master) disabled previously or in the spell
     * [ ] EITHER is used, depending on the instruction:

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -133,8 +133,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * [ ] Global debt ceiling (`vat.Line`) is updated accordingly, UNLESS specifically instructed not to
   * IF an ilk's `AutoLine` configuration is updated via `DssExecLib`
     * [ ] EITHER is used, depending on the instruction:
-      * [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L658)
-      * [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L648)
+      * [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/69b658f35d8618272cd139dfc18c5713caf6b96b/src/DssExecLib.sol#L665-L670)
+      * [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/69b658f35d8618272cd139dfc18c5713caf6b96b/src/DssExecLib.sol#L655-L659)
     * [ ] Each `DssExecLib` `AutoLine` setter call is immediately followed by `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)`
     * [ ] `AutoLine` updates are tested by asserting the configured parameters and the exact resulting per-ilk and global `Vat` debt ceilings after cast
   * IF [`DssAutoLine.setIlk(ilk, line, gap, ttl)`](https://github.com/sky-ecosystem/dss-auto-line/blob/master/src/DssAutoLine.sol#L81-L85) is called directly instead of using a `DssExecLib` AutoLine setter

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -140,7 +140,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * IF the Exec Sheet explicitly requires staged `AutoLine` configuration and live `Vat` debt-ceiling states
     * [ ] `DssAutoLine.setIlk(ilk, line, gap, ttl)` is used directly instead of a `DssExecLib` `AutoLine` setter
     * [ ] `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)` is called separately at each intended synchronization point
-    * [ ] Tests assert the intermediate and final `AutoLine` configuration and exact per-ilk and global `Vat` debt ceilings
+    * [ ] `AutoLine` values are tested via `testGeneral`
+    * [ ] `exec` calls are tested via `testAutoLineExecAfterEverySetIlkCall`
   * IF collateral debt ceiling (`vat.ilk.line`) is updated directly rather than through `AutoLine`
     * [ ] Collateral type (`ilk`) have [`AutoLine`](https://github.com/sky-ecosystem/dss-auto-line/tree/master) disabled previously or in the spell
     * [ ] EITHER is used, depending on the instruction:

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -136,7 +136,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
       * [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/69b658f35d8618272cd139dfc18c5713caf6b96b/src/DssExecLib.sol#L665-L670)
       * [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/69b658f35d8618272cd139dfc18c5713caf6b96b/src/DssExecLib.sol#L655-L659)
     * [ ] Each `DssExecLib` `AutoLine` setter call is immediately followed by `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)`
-    * [ ] `AutoLine` updates are tested by asserting the configured parameters and the exact resulting per-ilk and global `Vat` debt ceilings after cast
+    * [ ] `AutoLine` values are tested via `testGeneral`
+    * [ ] `exec` calls are tested via `testAutoLineExecAfterEverySetIlkCall`
   * IF the Exec Sheet explicitly requires staged `AutoLine` configuration and live `Vat` debt-ceiling states
     * [ ] `DssAutoLine.setIlk(ilk, line, gap, ttl)` is used directly instead of a `DssExecLib` `AutoLine` setter
     * [ ] `DssAutoLineAbstract(MCD_IAM_AUTO_LINE).exec(ilk)` is called separately at each intended synchronization point


### PR DESCRIPTION
This PR adds checklist coverage for `AutoLine` synchronization after parameter updates:
- Updating the crafter checklist to require `DssAutoLine.exec(ilk)` immediately after `DssExecLib` AutoLine setter calls
- Updating the reviewer checklist with the corresponding implementation and post-cast debt-ceiling checks
- Covering direct `DssAutoLine.setIlk(...)` usage when configuration and live Vat states are intentionally handled separately

This addresses the synchronization issue identified during the [July 16 spell review](https://github.com/sky-ecosystem/spells-mainnet/pull/559#discussion_r3595124109), where updating AutoLine parameters did not automatically propagate the resulting debt ceiling to the Vat.

Note: This is an interim checklist measure to prevent the issue from recurring. A future audited `DssExecLib` update is expected to handle this synchronization directly.