### PR TITLE
chore: update spell coordination and re-review checks

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -98,6 +98,7 @@ CalcFab
 calldata
 casted
 checksummed
+checkboxes
 codehash
 collateralization
 collaterals

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -157,6 +157,7 @@ setLiquidationBreakerPriceTolerance
 setStairstepExponentialDecrease
 solc
 startingPriceFactor
+strikethroughs
 structs
 submodule
 submodules

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -33,9 +33,11 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 - If a delay is expected, responsible party should provide new realistic time estimation
   - A delay in one stage completion shifts deadlines for all subsequent stages to the same amount of hours, unless spell team agrees otherwise
 
-* Create the spell-specific Signal group after content and roles are agreed
-  * [ ] Name the group `YYYY-MM-DD Spell`, where `YYYY-MM-DD` is the initial target date of the spell
-  * [ ] Add the assigned crafter and both official reviewers
+- Set up the spell-specific Signal group after content and roles are agreed in the `YYYY-MM-DD Executive Spell Coordination` Slack Thread
+  - [ ] Create the group named `YYYY-MM-DD Spell`
+  - [ ] Add both official reviewers
+  - IF other team members are involved in the spell
+    - [ ] Add them to the group
 
 ## Development Stage
 
@@ -258,8 +260,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Wait until both spell reviewers confirm the spell address in the Handover Thread
   * [ ] Tag Responsible Governance Facilitator in the private GovOps Slack coordination thread with the link to the handover message
   * [ ] Wait until Responsible Governance Facilitator confirms handover in the Handover Thread
-* IF the crafter owns the Exec Sheet update and has edit permission
-  * [ ] Fill the remaining Spell Crafter-related boxes in the Exec Sheet
+* IF there are remaining Spell Crafter-related fields in the Exec Sheet and the crafter is responsible for updating them
+  * [ ] Fill the remaining fields
 * Pre-Merge target branch pull attack checks
   * IF within last THREE commits (or last 6 weeks) spells-mainnet repo contains a maintenance PR
     * [ ] Ensure the PR actions match description and look safe

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -33,7 +33,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 - If a delay is expected, responsible party should provide new realistic time estimation
   - A delay in one stage completion shifts deadlines for all subsequent stages to the same amount of hours, unless spell team agrees otherwise
 
-- Set up the spell-specific Signal group after content and roles are agreed in the `YYYY-MM-DD Executive Spell Coordination` Slack Thread
+- Set up the spell Signal group after content and roles are agreed in the `YYYY-MM-DD Executive Spell Coordination` Slack Thread
   - [ ] Create the group named `YYYY-MM-DD Spell`
   - [ ] Add both official reviewers
   - IF other team members are involved in the spell

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -213,10 +213,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 ## Deployment Stage
 
-* [ ] Wait for at least two "good to deploy" comments (containing local tests) from the official reviewers
-* IF new commits are pushed after either "good to deploy" comment
-  * [ ] Notify both official reviewers
-  * [ ] Wait for both official reviewers to re-review the latest commit and publish new "good to deploy" comments before deployment
+* [ ] Before deploying, ensure both official reviewers have posted "good to deploy" comments (containing local tests) for the current pre-deployment commit
 * Pre-deploy setup and checks (currently via Foundry)
   * Set local environment variables
     * [ ] Avoid using the same deployer for different chains (to avoid deploying contracts with the same address but different source code)

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -33,7 +33,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 - If a delay is expected, responsible party should provide new realistic time estimation
   - A delay in one stage completion shifts deadlines for all subsequent stages to the same amount of hours, unless spell team agrees otherwise
 
-- Set up the spell Signal group after content and roles are agreed in the `YYYY-MM-DD Executive Spell Coordination` Slack Thread
+- Set up the spell Signal group after the content and roles have been agreed in the private GovOps Slack coordination thread
   - [ ] Create the group named `YYYY-MM-DD Spell`
   - [ ] Add both official reviewers
   - IF other team members are involved in the spell

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -33,7 +33,7 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 - If a delay is expected, responsible party should provide new realistic time estimation
   - A delay in one stage completion shifts deadlines for all subsequent stages to the same amount of hours, unless spell team agrees otherwise
 
-- Set up the spell Signal group after the content and roles have been agreed in the private GovOps Slack coordination thread
+- Set up the spell Signal group after the content and roles have been agreed upon in the private GovOps Slack coordination thread
   - [ ] Create the group named `YYYY-MM-DD Spell`
   - [ ] Add both official reviewers
   - IF other team members are involved in the spell

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -33,6 +33,10 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 - If a delay is expected, responsible party should provide new realistic time estimation
   - A delay in one stage completion shifts deadlines for all subsequent stages to the same amount of hours, unless spell team agrees otherwise
 
+* Create the spell-specific Signal group after content and roles are agreed
+  * [ ] Name the group `YYYY-MM-DD Spell`, where `YYYY-MM-DD` is the initial target date of the spell
+  * [ ] Add the assigned crafter and both official reviewers
+
 ## Development Stage
 
 * Install stable Foundry version
@@ -208,6 +212,9 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
 ## Deployment Stage
 
 * [ ] Wait for at least two "good to deploy" comments (containing local tests) from the official reviewers
+* IF new commits are pushed after either "good to deploy" comment
+  * [ ] Notify both official reviewers
+  * [ ] Wait for both official reviewers to re-review the latest commit and publish new "good to deploy" comments before deployment
 * Pre-deploy setup and checks (currently via Foundry)
   * Set local environment variables
     * [ ] Avoid using the same deployer for different chains (to avoid deploying contracts with the same address but different source code)
@@ -251,7 +258,8 @@ Repo: https://github.com/sky-ecosystem/spells-mainnet
   * [ ] Wait until both spell reviewers confirm the spell address in the Handover Thread
   * [ ] Tag Responsible Governance Facilitator in the private GovOps Slack coordination thread with the link to the handover message
   * [ ] Wait until Responsible Governance Facilitator confirms handover in the Handover Thread
-* [ ] Fill the rest of the Spell Crafter-related boxes in the Exec Sheet
+* IF the crafter owns the Exec Sheet update and has edit permission
+  * [ ] Fill the remaining Spell Crafter-related boxes in the Exec Sheet
 * Pre-Merge target branch pull attack checks
   * IF within last THREE commits (or last 6 weeks) spells-mainnet repo contains a maintenance PR
     * [ ] Ensure the PR actions match description and look safe

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -388,7 +388,7 @@ _Insert your local test logs here_
   * [ ] Check if chainlog needs to be updated
   * [ ] Copy over and redo "Tests" section from the above
 * [ ] Do a final review of the checklist comment before posting to ensure all checks are correct and complete
-* [ ] Check the rendered checklist comment before posting to ensure all check boxes and strikethroughs display correctly
+* [ ] Verify that all checkboxes and strikethroughs display correctly in the rendered checklist comment before posting
 * [ ] IF all checks pass, make sure to include explicit "Good to deploy" comment
 
 ## Deployed Stage

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -402,7 +402,7 @@ _Insert your local test logs here_
   * [ ] GNU AGPLv3 license
 * Source code validity
   * [ ] Deployed spell code matches source on github. (can be checked via `make diff-deployed-spell` or manually)
-  * [ ] Spell source code is unchanged from the pre-deployment commit approved as "good to deploy" by both official reviewers
+  * [ ] No new changes are made after the previously given "good to deploy" comments from both official reviewers, EXCEPT for archival and deployed-spell values in config
 * Deployed spell Etherscan checks
   * [ ] Ensure local code is up-to-date with the remote branch (e.g. `git pull`)
   * Automated checks via `make check-deployed-spell`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -380,8 +380,8 @@ _Insert your local test logs here_
   * [ ] Exec Doc URL in the spell comment refers to the [https://github.com/sky-ecosystem/executive-votes](https://github.com/sky-ecosystem/executive-votes) repository
   * [ ] Every action present in the spell code is present in the Exec Doc
   * [ ] Every action in the Exec Doc is present in the spell code
-* [ ] Latest remote spell commit matches the commit reviewed in this checklist
-  _Insert latest reviewed remote commit hash_
+* [ ] The commit reviewed in this checklist matches the latest commit in the spell PR
+  _Insert latest reviewed commit hash_
 * IF new commits are present after the previous review
   * [ ] Copy relevant checklist items from the above and redo them
   * [ ] Ensure newly added code is covered by tests

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -380,12 +380,15 @@ _Insert your local test logs here_
   * [ ] Exec Doc URL in the spell comment refers to the [https://github.com/sky-ecosystem/executive-votes](https://github.com/sky-ecosystem/executive-votes) repository
   * [ ] Every action present in the spell code is present in the Exec Doc
   * [ ] Every action in the Exec Doc is present in the spell code
+* [ ] Latest remote spell commit matches the commit reviewed in this checklist
+  _Insert latest reviewed remote commit hash_
 * IF new commits are present after the previous review
   * [ ] Copy relevant checklist items from the above and redo them
   * [ ] Ensure newly added code is covered by tests
   * [ ] Check if chainlog needs to be updated
   * [ ] Copy over and redo "Tests" section from the above
 * [ ] Do a final review of the checklist comment before posting to ensure all checks are correct and complete
+* [ ] Check the rendered checklist comment before posting to ensure all checkboxes and strikethroughs display correctly
 * [ ] IF all checks pass, make sure to include explicit "Good to deploy" comment
 
 ## Deployed Stage

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -387,7 +387,6 @@ _Insert your local test logs here_
   * [ ] Copy over and redo "Tests" section from the above
 * [ ] Do a final review of the checklist comment before posting to ensure all checks are correct and complete
 * [ ] IF all checks pass, make sure to include explicit "Good to deploy" comment
-* [ ] Ensure the checklist comment remains unedited after posting
 
 ## Deployed Stage
 

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -380,12 +380,15 @@ _Insert your local test logs here_
   * [ ] Exec Doc URL in the spell comment refers to the [https://github.com/sky-ecosystem/executive-votes](https://github.com/sky-ecosystem/executive-votes) repository
   * [ ] Every action present in the spell code is present in the Exec Doc
   * [ ] Every action in the Exec Doc is present in the spell code
-* IF new commits are present in the spell
+* IF new commits are present after the previous review
   * [ ] Copy relevant checklist items from the above and redo them
   * [ ] Ensure newly added code is covered by tests
   * [ ] Check if chainlog needs to be updated
   * [ ] Copy over and redo "Tests" section from the above
+  * [ ] IF a "Good to deploy" comment was already published, publish a new checklist comment with an explicit "Good to deploy" for the latest commit
+* [ ] Do a final review of the checklist comment before posting to ensure all checks are correct and complete
 * [ ] IF all checks pass, make sure to include explicit "Good to deploy" comment
+* [ ] Ensure the checklist comment remains unedited after posting
 
 ## Deployed Stage
 

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -385,7 +385,6 @@ _Insert your local test logs here_
   * [ ] Ensure newly added code is covered by tests
   * [ ] Check if chainlog needs to be updated
   * [ ] Copy over and redo "Tests" section from the above
-  * [ ] IF a "Good to deploy" comment was already published, publish a new checklist comment with an explicit "Good to deploy" for the latest commit
 * [ ] Do a final review of the checklist comment before posting to ensure all checks are correct and complete
 * [ ] IF all checks pass, make sure to include explicit "Good to deploy" comment
 * [ ] Ensure the checklist comment remains unedited after posting
@@ -404,7 +403,7 @@ _Insert your local test logs here_
   * [ ] GNU AGPLv3 license
 * Source code validity
   * [ ] Deployed spell code matches source on github. (can be checked via `make diff-deployed-spell` or manually)
-  * [ ] No changes were made to the spell source code after the latest commit approved as "good to deploy" by both official reviewers
+  * [ ] Spell source code is unchanged from the pre-deployment commit approved as "good to deploy" by both official reviewers
 * Deployed spell Etherscan checks
   * [ ] Ensure local code is up-to-date with the remote branch (e.g. `git pull`)
   * Automated checks via `make check-deployed-spell`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -404,7 +404,7 @@ _Insert your local test logs here_
   * [ ] GNU AGPLv3 license
 * Source code validity
   * [ ] Deployed spell code matches source on github. (can be checked via `make diff-deployed-spell` or manually)
-  * [ ] No new changes are made after previously given "good to deploy"
+  * [ ] No changes were made to the spell source code after the latest commit approved as "good to deploy" by both official reviewers
 * Deployed spell Etherscan checks
   * [ ] Ensure local code is up-to-date with the remote branch (e.g. `git pull`)
   * Automated checks via `make check-deployed-spell`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -388,7 +388,7 @@ _Insert your local test logs here_
   * [ ] Check if chainlog needs to be updated
   * [ ] Copy over and redo "Tests" section from the above
 * [ ] Do a final review of the checklist comment before posting to ensure all checks are correct and complete
-* [ ] Check the rendered checklist comment before posting to ensure all checkboxes and strikethroughs display correctly
+* [ ] Check the rendered checklist comment before posting to ensure all check boxes and strikethroughs display correctly
 * [ ] IF all checks pass, make sure to include explicit "Good to deploy" comment
 
 ## Deployed Stage


### PR DESCRIPTION
This PR updates the spell-crafting and review checklists to match the current process:

- Adding an explicit `YYYY-MM-DD Spell` Signal group setup step after content and roles are agreed
- Making remaining Spell Crafter Exec Sheet updates conditional on relevant fields being present and assigned to the crafter
- Making the re-review requirements and Deployment Stage checks clearer

The Star handover message update from #62 is intentionally left to #58 and #60 to avoid overlapping their active checklist changes.

Closes #64
Closes #65