### PR TITLE
Fix spell reviewer checklist provenance checks for self-governed Prime Agents

### DIFF
--- a/spell/star-spell-reviewer-checklist.md
+++ b/spell/star-spell-reviewer-checklist.md
@@ -241,7 +241,7 @@ EXECUTED_TESTS_LOGS
 - [ ] Actions taken in the spell match the scope approved through the governance process applicable to this Prime Agent:
   - [ ] IF Sky-governed, matches the corresponding [Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal) and, where required, governance poll.
   - [ ] IF Self-governed, matches the proposal forum post (often the technical scope forum post) and Snapshot vote, for changes to the Prime Agent's own artifact. Changes to the Sky Core Atlas still follow the same Atlas edit weekly proposal and governance poll process as Sky-governed Prime Agents.
-- [ ] Every _Instruction text_ from the governance record applicable to this Prime Agent is copied to the spell code as a comment.
+- [ ] Every _Action Item_ from the governance record applicable to this Prime Agent Spell is copied to the spell code as a comment.
 - [ ] IF an instruction cannot be taken, it should have an explanation under the instruction prefixed with `// Note:`.
 - [ ] IF an action in the spell doesn't have a relevant instruction, its necessity is explained in a comment prefixed with `// Note:`.
 - [ ] All actions present in the spell code are present in the governance record applicable to this Prime Agent.

--- a/spell/star-spell-reviewer-checklist.md
+++ b/spell/star-spell-reviewer-checklist.md
@@ -217,7 +217,7 @@ This section outlines the review process and provides concrete action items for 
 #### Parameter Changes & Protocol Integration
 - [ ] Prime Agent protocol invariants are maintained after spell execution.
 - [ ] All parameter changes use the appropriate helper functions IF available.
-- [ ] Parameter changes match the governance record applicable to this Prime Agent exactly (see [Pre-Deployment checks](#pre-deployment-checks)).
+- [ ] Parameter changes match the governance record applicable to this Prime Agent Spell exactly: the corresponding Atlas edit weekly proposal (Sky-governed), or the proposal forum post and Snapshot vote (self-governed, for changes to the Prime Agent's own artifact).
 - [ ] Spell interacts correctly with existing protocol components.
 - [ ] Proper error handling for all external interactions.
 

--- a/spell/star-spell-reviewer-checklist.md
+++ b/spell/star-spell-reviewer-checklist.md
@@ -138,7 +138,7 @@ This section outlines the review process and provides concrete action items for 
     - [ ] Forum post follows the [known template](https://github.com/Atlas-Axis/ecosystem-operational-references/blob/main/templates/technical-scope-template.md).
 - [ ] Verify spell content matches the combined scope of the forum posts listed above.
 - [ ] Verify forum posts contain all new addresses directly or indirectly used in the spell, their constructor arguments and rate limits.
-- [ ] IF the Prime Agent spell introduces a major change that can affect external parties, suggest Governance Facilitators to set Core Spell office hours to `true`.
+- [ ] IF the Prime Agent spell introduces a major change that can affect external parties, suggest the Core Facilitator to set Core Spell office hours to `true`.
 
 #### Contract Structure & Code Quality
 - [ ] The only external non-view function in the spell contract is `execute()`.
@@ -217,7 +217,7 @@ This section outlines the review process and provides concrete action items for 
 #### Parameter Changes & Protocol Integration
 - [ ] Prime Agent protocol invariants are maintained after spell execution.
 - [ ] All parameter changes use the appropriate helper functions IF available.
-- [ ] Parameter changes match the Executive Sheet or the corresponding Atlas edit exactly.
+- [ ] Parameter changes match the governance record applicable to this Prime Agent exactly (see [Pre-Deployment checks](#pre-deployment-checks)).
 - [ ] Spell interacts correctly with existing protocol components.
 - [ ] Proper error handling for all external interactions.
 
@@ -238,16 +238,13 @@ EXECUTED_TESTS_LOGS
 ```
 
 #### Pre-Deployment checks
-- [ ] Actions listed in the [Executive Sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw/edit) for this Star match the spell scope.
-  - [ ] IF Executive Sheet is not yet ready at the time of review, reference [the corresponding Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal)
-- [ ] Every _Instruction text_ from the Executive Sheet is copied to the spell code as a comment.
-  - [ ] IF Executive Sheet is not yet ready at the time of review, reference [the corresponding Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal)
+- [ ] Actions taken in the spell match the scope approved through the governance process applicable to this Prime Agent:
+  - [ ] IF Sky-governed, matches the corresponding [Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal) and, where required, governance poll.
+  - [ ] IF Self-governed, matches the proposal forum post (often the technical scope forum post) and Snapshot vote, for changes to the Prime Agent's own artifact. Changes to the Sky Core Atlas still follow the same Atlas edit weekly proposal and governance poll process as Sky-governed Prime Agents.
+- [ ] Every _Instruction text_ from the governance record applicable to this Prime Agent is copied to the spell code as a comment.
 - [ ] IF an instruction cannot be taken, it should have an explanation under the instruction prefixed with `// Note:`.
 - [ ] IF an action in the spell doesn't have a relevant instruction, its necessity is explained in a comment prefixed with `// Note:`.
-- [ ] All actions present in the spell code are present in the final Executive Sheet.
-  - [ ] IF Executive Sheet is not yet ready at the time of review, reference [the corresponding Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal)
-- [ ] All actions in the final Executive Sheet are present in the spell code.
-  - [ ] IF Executive Sheet is not yet ready at the time of review, reference [the corresponding Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal)
+- [ ] All actions present in the spell code are present in the governance record applicable to this Prime Agent.
 - [ ] IF new commits were added after the initial review, the relevant checklist items have been re-verified.
 - [ ] IF no blockers were found, post the completed "Development Stage" checklist stage with the explicit "Good to deploy" note on top.
 

--- a/spell/star-spell-reviewer-checklist.md
+++ b/spell/star-spell-reviewer-checklist.md
@@ -238,9 +238,11 @@ EXECUTED_TESTS_LOGS
 ```
 
 #### Pre-Deployment checks
-- [ ] Actions taken in the spell match the scope approved through the governance process applicable to this Prime Agent Spell:
+- [ ] Actions taken in the spell match the scope approved through the governance record applicable to this Prime Agent Spell:
   - [ ] IF Sky-governed, matches the corresponding [Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal) and, where required, governance poll.
   - [ ] IF Self-governed, matches the proposal forum post (often the technical scope forum post) and Snapshot vote, for changes to the Prime Agent's own artifact. Changes to the Sky Core Atlas still follow the same Atlas edit weekly proposal and governance poll process as Sky-governed Prime Agents.
+  - [ ] Extract the permanent URL to the governance record used for comparison and paste it below:
+    _Insert your Governance Record URL here_
 - [ ] Every _Action Item_ from the governance record applicable to this Prime Agent Spell is copied to the spell code as a comment.
 - [ ] IF an instruction cannot be taken, it should have an explanation under the instruction prefixed with `// Note:`.
 - [ ] IF an action in the spell doesn't have a relevant instruction, its necessity is explained in a comment prefixed with `// Note:`.

--- a/spell/star-spell-reviewer-checklist.md
+++ b/spell/star-spell-reviewer-checklist.md
@@ -238,7 +238,7 @@ EXECUTED_TESTS_LOGS
 ```
 
 #### Pre-Deployment checks
-- [ ] Actions taken in the spell match the scope approved through the governance process applicable to this Prime Agent:
+- [ ] Actions taken in the spell match the scope approved through the governance process applicable to this Prime Agent Spell:
   - [ ] IF Sky-governed, matches the corresponding [Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal) and, where required, governance poll.
   - [ ] IF Self-governed, matches the proposal forum post (often the technical scope forum post) and Snapshot vote, for changes to the Prime Agent's own artifact. Changes to the Sky Core Atlas still follow the same Atlas edit weekly proposal and governance poll process as Sky-governed Prime Agents.
 - [ ] Every _Action Item_ from the governance record applicable to this Prime Agent Spell is copied to the spell code as a comment.

--- a/spell/star-spell-reviewer-checklist.md
+++ b/spell/star-spell-reviewer-checklist.md
@@ -244,7 +244,7 @@ EXECUTED_TESTS_LOGS
 - [ ] Every _Action Item_ from the governance record applicable to this Prime Agent Spell is copied to the spell code as a comment.
 - [ ] IF an instruction cannot be taken, it should have an explanation under the instruction prefixed with `// Note:`.
 - [ ] IF an action in the spell doesn't have a relevant instruction, its necessity is explained in a comment prefixed with `// Note:`.
-- [ ] All actions present in the spell code are present in the governance record applicable to this Prime Agent.
+- [ ] All actions present in the spell code are present in the governance record applicable to this Prime Agent Spell.
 - [ ] IF new commits were added after the initial review, the relevant checklist items have been re-verified.
 - [ ] IF no blockers were found, post the completed "Development Stage" checklist stage with the explicit "Good to deploy" note on top.
 

--- a/spell/star-spell-reviewer-checklist.md
+++ b/spell/star-spell-reviewer-checklist.md
@@ -244,7 +244,9 @@ EXECUTED_TESTS_LOGS
 - [ ] Every _Action Item_ from the governance record applicable to this Prime Agent Spell is copied to the spell code as a comment.
 - [ ] IF an instruction cannot be taken, it should have an explanation under the instruction prefixed with `// Note:`.
 - [ ] IF an action in the spell doesn't have a relevant instruction, its necessity is explained in a comment prefixed with `// Note:`.
-- [ ] All actions present in the spell code are present in the governance record applicable to this Prime Agent Spell.
+- [ ] Actions in the spell code and the governance record applicable to this Prime Agent Spell match in both directions:
+  - [ ] All actions present in the spell code are present in the governance record.
+  - [ ] All actions in the governance record that are relevant to this spell are present in the spell code.
 - [ ] IF new commits were added after the initial review, the relevant checklist items have been re-verified.
 - [ ] IF no blockers were found, post the completed "Development Stage" checklist stage with the explicit "Good to deploy" note on top.
 


### PR DESCRIPTION
## Motivation
Grove and Spark are now self-governed: most of their Prime-artifact updates go through a Snapshot vote and a proposal forum post (often the technical scope forum post), rather than a Sky Core Atlas edit weekly proposal and governance poll. The checklist's Pre-Deployment checks section only recognized the Atlas edit proposal path (as a fallback when the Executive Sheet wasn't ready), which doesn't apply to Grove/Spark's Prime-artifact changes.

The Executive Sheet requirement also doesn't match the actual review timeline. Internal review happens before the Monday 8am CET handover; external review happens anytime between Monday and Thursday; the Executive Sheet is seldom populated until Friday. By the time either reviewer checks the spell against it, it's very often not there yet — this is exactly what happened during external review of the 2026-08-13 Grove spell.

## What changed
1. **Pre-Deployment checks now branch by governance model** instead of assuming a single path (examples dropped per Kohla's feedback — naming specific Prime Agents goes stale the moment one changes governance bucket):
   - Sky-governed Prime Agents: Atlas edit weekly proposal + governance poll, as before.
   - Self-governed Prime Agents: the proposal forum post (often the technical scope forum post) + Snapshot vote, for changes to the Prime Agent's own artifact. Changes to the Sky Core Atlas itself still go through the same Atlas edit weekly proposal + governance poll process as Sky-governed Prime Agents — self-governance only covers the Prime Agent's own artifact, not the shared Atlas.
2. **Removed the Executive Sheet as the primary/required source.** In practice it's rarely ready by the time a spell is under review, so requiring it (with a conditional fallback) added friction without adding reliability. The applicable governance record is now the primary source of truth for what the spell should contain.
3. Updated the parallel bullet under **Parameter Changes & Protocol Integration** for consistency.
4. **Renamed "Governance Facilitators" to "Core Facilitator"** in the Proposed changes section. The Governance Facilitator concept has been superseded — the role is now referenced as the Core Facilitator, held by team Jansky.
5. **Dropped the "record → spell" direction of the provenance check.** The old checklist verified both directions — spell actions are all present in the source, and the source's actions are all present in the spell — which made sense against an Executive Sheet scoped to exactly one spell. A governance poll, Atlas edit proposal, or Snapshot vote can legitimately bundle items for other spells or future target dates, so requiring every item in the record to show up in this spell would flag correct spells as incomplete. The "spell → record" direction (nothing in the spell is unapproved) is unaffected and still required.

   If we want to keep the Executive Sheet as the primary source, we'd need to communicate with the Core Facilitator to make sure the sheet is ready for the Prime items earlier in the week — maybe even around Wednesday. This isn't decided yet, just a suggestion worth considering.

## Why this is safe
- The check that catches unapproved/out-of-scope actions in the spell (spell actions must all trace back to an approved source) is unchanged.
- The dropped check only ever caught a false-positive class of problem once the source could span more than one spell's worth of items — see item 5 above.
- Makes explicit what reviewers were already doing informally for Grove, rather than introducing new process.

